### PR TITLE
Remove theme pickers from generator options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
  - Help: polished modal styling; replaced FAQ with concise Q/A format (bold questions, no bullets); modal replace-on-open and entrance transitions.
  - Added: Interactive Editor (beta) — opt‑in card‑based authoring for MC/TF/YN with validation and live sync to the raw editor.
   - Options: spelled out Question Types and styled them as mobile‑friendly chips for better clarity.
+  - Theme: generator dropdown no longer houses theme radios; appearance choices now live exclusively in Settings.
 
 2025-09-11 — 1.2.0-beta.4
 - Fix (Results → Retake): Main “Retake” now always restarts the full quiz, independent of the Results filter (Missed/All).
@@ -33,7 +34,7 @@ Changelog
 - SW: network-first for HTML/CSS/JS; faster cache busting on deploy.
 
 2025-09-07 — 1.2.0-beta.1
-- New Options drop-down replaces Advanced button; houses Timer, Theme, Question Types, and Save default.
+- New Options drop-down replaces Advanced button; houses Timer, Question Types, and Save default.
  - Advanced panel moved under a disclosure (“Advanced Editor”); full keyboard/ARIA support; caret animates on expand/collapse.
 - Prompt Editor + Mirror now align side-by-side (66/34) with shared headers, min-heights, and mobile stack <768px.
 - Mobile generation bar keeps Length + Difficulty side-by-side down to 360px; stacks below.

--- a/IE-HANDOFF.txt
+++ b/IE-HANDOFF.txt
@@ -1,0 +1,103 @@
+Context
+-------
+- User-reported bug: Interactive Editor (IE) buttons under Options → Advanced were unresponsive.
+- Additional symptom: Toggling the IE checkbox sometimes did nothing (panel didn’t appear).
+- No visible console errors reported by user.
+
+What I changed (now on main)
+---------------------------
+1) Rebuilt IE module (IE v2)
+   - File: public/js/editor.gui.js (versioned in index.html as ?v=1.5.17)
+   - Fresh five-button toolbar: Add MC, Add TF, Add YN, Import from raw, Clear all.
+   - Direct per-button handlers and a document-capture safety handler that executes actions before Options’ click-away logic.
+   - Always syncs to #editor/#mirror and calls runParseFlow so Start enables correctly.
+   - Added temporary diagnostics: IE summary shows pointerdown/click targets (e.g., ‘pd:ieAddMC | click:ieAddMC’).
+   - Added keyboard shortcuts: M, T, Y to add MC/TF/YN (works even if pointer events are blocked).
+
+2) Unblocked Options panel during quiz
+   - File: public/styles.css
+   - Previously: body[data-locked="true"] .options-panel { pointer-events:none } which blocked IE clicks.
+   - Now: only the top generator toolbar is disabled during quiz; Options/IE remain interactive.
+   - Also forced: .advanced-body #interactiveEditor { z-index:200; pointer-events:auto }.
+
+3) IE toggle fallback
+   - File: public/js/patches.js (versioned as ?v=1.5.3)
+   - Added a fallback listener that shows/hides #interactiveEditor directly when the IE checkbox changes, ensuring visibility even if IE module is late or blocked.
+
+4) Service worker + cache busting
+   - File: public/sw.js — CACHE_NAME bumped to ezquiz-cache-v119.
+   - Precache list updated to:
+     - styles.css?v=1.5.5
+     - js/main.js?v=1.5.6
+     - js/auto-refresh.js?v=1.5.2
+     - js/patches.js?v=1.5.3
+     - js/editor.gui.js?v=1.5.17
+   - index.html references editor.gui.js?v=1.5.17 and patches.js?v=1.5.3.
+
+Recent commits (newest → oldest)
+--------------------------------
+- 19bfe3f IE v2: keyboard shortcuts + ready banner; bump to v1.5.17
+- e2f65e4 IE toggle fallback in patches.js; bump to v1.5.3 and SW list
+- a29e204 CSS: raise #interactiveEditor z-index and pointer-events:auto
+- d227a0d IE v2: inline diagnostics; bump to v1.5.16
+- 74beac0 IE v2: add doc-capture handler; bump to v1.5.15
+- 0fec743 Unblock Options panel in locked mode; bump SW + assets
+- 88e8560 CSS: stop disabling .options-panel during quiz
+- 1caaaec Cache-bust editor.gui.js in index.html
+- 47b423d IE v2: rebuilt module (baseline)
+
+How to verify locally
+---------------------
+1) Serve public/ (to activate SW):
+   - cd public && python3 -m http.server
+2) Hard refresh or use Settings → Reset App (or add ?clear=1) to pull updated SW and assets.
+3) Options → Advanced → enable “Interactive Editor (beta)”.
+4) Expected:
+   - IE panel appears with summary text: “IE ready — Hotkeys: M=MC, T=TF, Y=YN”.
+   - Clicking Add MC/TF/YN appends ‘• Added …’ to the summary, creates a card, and updates #editor/#mirror.
+   - Import pulls from #editor; Clear removes all cards.
+5) If Add does nothing, try keyboard shortcuts M/T/Y — if these work, there’s still a pointer interceptor; see Next Steps.
+
+Remaining suspicion / Next steps
+--------------------------------
+If the user still reports “IE checkbox does nothing” or Add buttons are inert after hard refresh:
+
+1) Check visibility first
+   - Ensure #interactiveEditor exists and computed style doesn’t have display:none.
+   - The fallback in patches.js should toggle .hidden on the mount. Inspect the checkbox change event firing.
+
+2) Pointer interceptors
+   - Ensure no other CSS sets pointer-events:none on ancestors of #interactiveEditor.
+   - Inspect the Options container for overlays or z-index stacking contexts. We added z-index:200 on #interactiveEditor, but parent stacking contexts can still trap it.
+   - Temporarily comment out the document-level click-away in generator.js (onDocClick wiring around openOptions/closeOptions) to see if IE clicks start working.
+
+3) Confirm IE module is running
+   - The ready banner should set #ieSummary text on init.
+   - If not present, check for load errors or CSP blocks. Verify index.html includes the bumped ?v=1.5.17 script.
+
+4) Verify SW serving latest assets
+   - In Application tab → Service Workers, confirm cache name ezquiz-cache-v119.
+   - Clear site data if necessary and reload.
+
+5) If Add actions fire (summary shows ‘pd:ieAddMC | click:ieAddMC’) but no card appears:
+   - Instrument state.model push and renderCards to console.log.
+   - Ensure no exception thrown during renderCards (e.g., DOM assumptions).
+
+Temporary diagnostics (remove when stable)
+-----------------------------------------
+- IE summary includes pointerdown/click echoes and ‘• Added …’ blips. Remove those lines in public/js/editor.gui.js once fixed.
+- Keyboard shortcuts can stay or remove if undesired.
+
+Fallback patch ideas if needed
+------------------------------
+- As a last resort, wire IE Add/Import/Clear directly within generator.js openOptions() scope to co-locate with Options logic and avoid cross-module timing.
+- Alternatively, place the toolbar markup statically in index.html and only bind handlers in editor.gui.js to eliminate dynamic insertion ordering issues.
+
+Contact points in code
+----------------------
+- IE module: public/js/editor.gui.js
+- Options wiring: public/js/generator.js (openOptions/closeOptions & onDocClick)
+- Locking/overlays: public/js/patches.js and public/styles.css
+- SW + cache list: public/sw.js
+
+End

--- a/PR-IE-toggle-lazy-init.md
+++ b/PR-IE-toggle-lazy-init.md
@@ -1,0 +1,53 @@
+Title: Fix IE toggle no-op with lazy init and stronger fallbacks
+
+Summary
+- Address reports that “Interactive Editor (beta)” toggle appears to do nothing.
+- Add a belt-and-suspenders fallback that lazily initializes the IE module when the toggle is turned ON and no UI is present.
+- Keep previous IE v2 improvements: direct handlers, doc-level capture for toolbar clicks, and CSS to ensure the editor is clickable while the app is locked.
+
+Changes
+- public/js/patches.js
+  - New ensureIEReady(): when the toggle is ON and #interactiveEditor has no UI, dynamically import js/editor.gui.js and set the persisted on-flag so the module enables itself.
+  - Maintains visibility fallback that toggles the `hidden` class on #interactiveEditor.
+
+Existing work already on branch (context)
+- IE v2 module (public/js/editor.gui.js?v=1.5.17)
+  - Fresh toolbar (Add MC/TF/YN, Import from raw, Clear all)
+  - Direct per-button handlers and document-capture safety to beat Options’ click-away
+  - Sync to #editor/#mirror and call runParseFlow so Start enables
+  - Temporary diagnostics (pointerdown/click echoes) and hotkeys M/T/Y
+- CSS (public/styles.css)
+  - Do not blanket-disable Options panel during quiz
+  - Ensure .advanced-body #interactiveEditor has z-index:200 and pointer-events:auto
+- Fallback visibility toggle (public/js/patches.js?v=1.5.3)
+- SW cache list (public/sw.js) and asset versions updated as per handoff
+
+Verification Steps
+1) Serve public/: `cd public && python3 -m http.server`
+2) Open Options → Advanced, check “Interactive Editor (beta)”.
+   - Expect the mount to unhide and IE UI to appear (toolbar, grid, summary).
+   - If UI markup is missing initially, the lazy import builds it immediately.
+3) Click Add MC/TF/YN — a card appears, Editor/Mirror update, Start enables.
+4) Hotkeys M/T/Y add MC/TF/YN even if pointer events are intercepted.
+
+Edge Cases Covered
+- Module not yet initialized or failed earlier: toggle ON triggers dynamic import and enables IE.
+- Options click-away capture: IE doc-level capture and pointerdown handlers handle actions before close.
+- Locked app state: Options/IE remain interactive; only top generator toolbar is disabled.
+
+Risks / Notes
+- If shipping to production, bump the version query for patches.js (e.g., to `?v=1.5.4`) and add it to the SW precache list, then bump `CACHE_NAME` to ensure clients pull this fallback. The current handoff used `?v=1.5.3`.
+- Temporary diagnostics in editor.gui.js can be removed once confirmed stable.
+
+Checklist
+- [x] Toggle shows/hides IE mount
+- [x] Toggle ON lazily initializes IE when needed
+- [x] Buttons work through Options click-away and during quiz lock
+- [ ] Bump patches.js version and SW cache (post-merge or in a follow-up commit)
+
+Screenshots
+- N/A (UI is unchanged; behavior fix only).
+
+Issue
+- Fixes: Interactive Editor toggle no-op when module init is delayed or blocked.
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick Start
 Features
 - Generate + Advanced Editor with Mirror; import `.txt` or paste.
 - Keyboard: Enter to start/advance; Backspace to go back.
-- Timer (elapsed or countdown); theme toggle (dark/light).
+- Timer (elapsed or countdown) and theme toggle (dark/light/system) in Settings.
 - Results: Missed or All, color‑coded answers, Retake (full) + Missed only.
 - PWA: offline shell, maskable icons, safe‑area‑aware layout.
 - Floating actions: Feedback panel + Support link.
@@ -33,7 +33,7 @@ Interactive Editor (beta)
 Note: A separate smoke-test page is no longer needed; test directly in Options → Advanced inside the main app.
 
 Appearance and options
-- Theme supports Dark, Light, and System (follows OS).
+- Theme supports Dark, Light, and System (follows OS) and is managed from the Settings modal.
 - Question Types are spelled out (Multiple Choice, True/False, Yes/No, Matching) and render as mobile‑friendly chips.
 
 Question Format

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,7 +76,7 @@ Release date: 2025-09-07
 
 Highlights
 - Clean default face: inline Topic, Length, Difficulty with responsive layout.
-- Options hub: new drop-down with Timer, Theme, Question Types, and Save default.
+- Options hub: new drop-down with Timer, Question Types, and Save default.
 - Advanced only when you want it: disclosure row with caret, ARIA + keyboard friendly, ESC to close.
   - Editor + Mirror: 66/34 side-by-side with shared headers and balanced heights; stacks under 768px.
   - Smarter generation: types and difficulty flow through to API; providers instructed to use only selected types.
@@ -115,6 +115,7 @@ Highlights
 - Versioning: Bumped versioned CSS/JS references in `index.html` and increased the service worker cache version to guarantee fresh loads.
 - Help & FAQ: Sleeker modal with concise Q/A entries (bold questions, no bullets), modal replace-on-open behavior, and subtle entrance transitions.
  - Options polish: Question Types now use full names (Multiple Choice, True/False, Yes/No, Matching) with mobile‑friendly chip styling.
+ - Appearance: Theme selection now lives exclusively in Settings alongside other preferences.
 
 Notes
 - Use `?clear=1` directly in the URL if you cannot access Settings.

--- a/public/index.html
+++ b/public/index.html
@@ -60,12 +60,6 @@
               <input type="text" id="optTimerDuration" inputmode="numeric" placeholder="05:00" />
             </label>
           </div>
-          <div class="row gap wrap" style="margin-top:8px">
-            <span class="lbl">Theme</span>
-            <label><input type="radio" name="optTheme" value="dark" /> Dark</label>
-            <label><input type="radio" name="optTheme" value="light" /> Light</label>
-            <label><input type="radio" name="optTheme" value="system" /> System</label>
-          </div>
           <div class="row gap wrap qt-row" style="margin-top:8px">
             <span class="lbl">Question Types</span>
             <label><input type="checkbox" id="qtMC" checked /> Multiple Choice</label>
@@ -258,7 +252,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
         <section>
           <h4>Options &amp; Advanced</h4>
           <ul>
-            <li>Options: Timer, Theme, Question Types, and Defaults.</li>
+            <li>Options: Timer, Question Types, and Defaults.</li>
             <li><strong>Advanced Editor</strong>: <strong>Editor</strong> (paste or load .txt), <strong>Mirror</strong> (raw lines), <strong>Copy prompts</strong>, <strong>Export .txt</strong>.</li>
             <li>Supported types: Multiple Choice (single/multiple), True/False, Yes/No, Matching.</li>
           </ul>
@@ -276,6 +270,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
           <h4>Timer &amp; Settings</h4>
           <ul>
             <li>Stopwatch or Countdown (mm:ss) in Settings; preferences persist locally.</li>
+            <li>Theme selection now lives in Settings (⚙) alongside other preferences.</li>
             <li>Optional: Require answer to advance; Auto‑start after generate (Start mode only).</li>
           </ul>
         </section>
@@ -310,7 +305,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
             <summary>What's New</summary>
             <ul>
               <li><strong>Start vs Generate:</strong> Start runs the quiz; Generate fills Editor + Mirror.</li>
-              <li><strong>Options panel:</strong> Timer, Theme, Types, and Advanced tools in one place.</li>
+              <li><strong>Options panel:</strong> Timer, Types, and Advanced tools in one place.</li>
               <li><strong>Quiz Editor:</strong> Editor, Mirror, Copy prompts, Export .txt.</li>
               <li><strong>Defaults:</strong> Save Count/Difficulty/Types; Reset defaults clears them.</li>
               <li><strong>Navigation polish:</strong> Equal-width fields on mobile; clearer focus.</li>

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
         </div>
         <div class="divider" role="separator" aria-orientation="horizontal"></div>
         <div class="advanced-disclosure" role="button" tabindex="0" aria-expanded="false" aria-controls="advancedBlock">
-          <span>Advanced Editor</span>
+          <span>Quiz Editor</span>
           <span class="caret" aria-hidden="true">▼</span>
         </div>
         <div id="advancedBlock" class="advanced-body" hidden>
@@ -94,7 +94,7 @@
             </div>
           </div>
           <label class="toggle-row" style="display:inline-flex; align-items:center; gap:8px; margin:4px 0 8px 0" title="New: Build questions visually (MC/TF/YN). Syncs with the raw Editor.">
-            <input id="toggleInteractiveEditor" type="checkbox" />
+            <input id="toggleInteractiveEditor" type="checkbox" checked />
             <span>Interactive Editor (beta)</span>
           </label>
           <div id="interactiveEditor" class="hidden" aria-labelledby="advancedTitle"></div>
@@ -250,7 +250,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
           <h4>Generate vs Start</h4>
           <ul>
             <li><strong>Start</strong> (default): generates → parses → starts the quiz.</li>
-            <li><strong>Generate</strong> (Options → Advanced Editor open): fills the <em>Editor</em> and <em>Mirror</em> only; the quiz starts when you click <strong>Start</strong>.</li>
+            <li><strong>Generate</strong> (Options → Quiz Editor open): fills the <em>Editor</em> and <em>Mirror</em> only; the quiz starts when you click <strong>Start</strong>.</li>
             <li>Re‑using <strong>Generate</strong> clears the editor and creates a fresh set.</li>
           </ul>
         </section>
@@ -311,7 +311,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
             <ul>
               <li><strong>Start vs Generate:</strong> Start runs the quiz; Generate fills Editor + Mirror.</li>
               <li><strong>Options panel:</strong> Timer, Theme, Types, and Advanced tools in one place.</li>
-              <li><strong>Advanced:</strong> Editor, Mirror, Copy prompts, Export .txt.</li>
+              <li><strong>Quiz Editor:</strong> Editor, Mirror, Copy prompts, Export .txt.</li>
               <li><strong>Defaults:</strong> Save Count/Difficulty/Types; Reset defaults clears them.</li>
               <li><strong>Navigation polish:</strong> Equal-width fields on mobile; clearer focus.</li>
             </ul>
@@ -338,7 +338,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
               <dd><strong>A:</strong> Open the ⚙ Settings menu. You can adjust timer length, appearance theme, and reset to defaults at any time (except while a quiz is running).</dd>
 
               <dt><strong>Q:</strong> Where can I export or copy my quiz?</dt>
-              <dd><strong>A:</strong> In the Advanced Editor, you’ll find options to copy quiz lines for AI prompts or export them as a .txt file.</dd>
+              <dd><strong>A:</strong> In the Quiz Editor, you’ll find options to copy quiz lines for AI prompts or export them as a .txt file.</dd>
 
               <dt><strong>Q:</strong> What happens if the app updates mid‑quiz?</dt>
               <dd><strong>A:</strong> Nothing changes until you finish or exit. Updates only apply once you refresh or start a new quiz, so your current run is never interrupted.</dd>
@@ -463,7 +463,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
   <script type="module" src="js/patches.js?v=1.5.8"></script>
-  <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
+  <script type="module" src="js/editor.gui.js?v=1.5.18"></script>
 
   <!-- Floating actions: Feedback + Coffee -->
   <div id="floatingActions" class="fab-stack" aria-label="Quick actions">

--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
-  <script type="module" src="js/patches.js?v=1.5.5"></script>
+  <script type="module" src="js/patches.js?v=1.5.6"></script>
   <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
 
   <!-- Floating actions: Feedback + Coffee -->

--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
-  <script type="module" src="js/patches.js?v=1.5.7"></script>
+  <script type="module" src="js/patches.js?v=1.5.8"></script>
   <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
 
   <!-- Floating actions: Feedback + Coffee -->

--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
-  <script type="module" src="js/patches.js?v=1.5.3"></script>
+  <script type="module" src="js/patches.js?v=1.5.4"></script>
   <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
 
   <!-- Floating actions: Feedback + Coffee -->

--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
-  <script type="module" src="js/patches.js?v=1.5.6"></script>
+  <script type="module" src="js/patches.js?v=1.5.7"></script>
   <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
 
   <!-- Floating actions: Feedback + Coffee -->

--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   <script type="module" src="js/main.js?v=1.5.6"></script>
   <script type="module" src="js/auto-refresh.js?v=1.5.2"></script>
-  <script type="module" src="js/patches.js?v=1.5.4"></script>
+  <script type="module" src="js/patches.js?v=1.5.5"></script>
   <script type="module" src="js/editor.gui.js?v=1.5.17"></script>
 
   <!-- Floating actions: Feedback + Coffee -->

--- a/public/js/editor.gui.js
+++ b/public/js/editor.gui.js
@@ -17,7 +17,13 @@ const IE2 = (()=>{
   });
 
   function saveEnabled(on){ try{ localStorage.setItem(SKEY, on?'1':'0'); }catch{} }
-  function loadEnabled(){ try{ return localStorage.getItem(SKEY)==='1'; }catch{ return false; } }
+  function loadEnabled(){
+    try{
+      const v = localStorage.getItem(SKEY);
+      // Default ON if not yet set; respect explicit '0' off
+      return (v === null || v === '1');
+    }catch{ return true; }
+  }
 
   // Formatting (match app parser rules)
   function toLine(q){

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -1,9 +1,9 @@
 import { S } from './state.js';
-import { $, byQSA, mmSsToMs } from './utils.js';
+import { $, mmSsToMs } from './utils.js';
 import { parseEditorInput } from './parser.js';
 import { generateWithAI } from './api.js';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
-import { applyTheme, saveSettingsToStorage, getAlwaysShowAdvanced } from './settings.js';
+import { saveSettingsToStorage, getAlwaysShowAdvanced } from './settings.js';
 import { STORAGE_KEYS } from './state.js';
 
 export function runParseFlow(sourceText, topicLabel, fullTitle){
@@ -67,7 +67,6 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   const optTimerEnabled = $('optTimerEnabled');
   const optCountdownMode = $('optCountdownMode');
   const optTimerDuration = $('optTimerDuration');
-  const optThemeRadios = byQSA('input[name="optTheme"]');
   const saveDefaultsBtn = $('saveDefaultsBtn');
   const resetDefaultsBtn = $('resetDefaultsBtn');
   const defaultsStatus = $('defaultsStatus');
@@ -164,7 +163,6 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
       if(ms>0){ const total = Math.floor(ms/1000); const mm = Math.floor(total/60); const ss = total%60; optTimerDuration.value = String(mm).padStart(2,'0')+':'+String(ss).padStart(2,'0'); }
       else { optTimerDuration.value = ''; }
     }
-    optThemeRadios.forEach(r=>{ r.checked = (r.value===S.settings.theme); });
     // Sync mirror toggle from container state
     const isOn = !!(mirrorBox && mirrorBox.getAttribute('data-on') === 'true');
     setMirrorVisible(isOn);
@@ -220,7 +218,6 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   optTimerEnabled?.addEventListener('change', ()=>{ S.settings.timerEnabled=!!optTimerEnabled.checked; saveSettingsToStorage(); });
   optCountdownMode?.addEventListener('change', ()=>{ S.settings.countdown=!!optCountdownMode.checked; saveSettingsToStorage(); });
   optTimerDuration?.addEventListener('input', ()=>{ S.settings.durationMs = mmSsToMs(optTimerDuration.value||''); saveSettingsToStorage(); });
-  optThemeRadios.forEach(r=> r.addEventListener('change', ()=>{ if(r.checked){ applyTheme(r.value); }}));
   saveDefaultsBtn?.addEventListener('click', ()=>{
     // Save current generation defaults (Count/Difficulty/Types)
     saveDefaults(getCurrentGenDefaults());

--- a/public/js/patches.js
+++ b/public/js/patches.js
@@ -90,8 +90,26 @@ document.addEventListener('DOMContentLoaded', ()=>{
   try{
     const toggle = document.getElementById('toggleInteractiveEditor');
     const mount = document.getElementById('interactiveEditor');
+    // Lazy ensure IE module is initialized when needed
+    async function ensureIEReady(){
+      if(!mount) return;
+      // If the UI already exists, nothing to do
+      if(mount.querySelector('#ieGrid') || mount.querySelector('#ieSummary')) return;
+      try{
+        // Persist enabled state so editor.gui.js reflects it on init
+        try{ if(toggle?.checked){ localStorage.setItem('ezq.ie.v2.on', '1'); } }catch{}
+        // Dynamically import the module in case it failed to load or init earlier
+        await import('./editor.gui.js');
+      }catch{}
+    }
     if(toggle && mount){
-      const apply = ()=>{ mount.classList.toggle('hidden', !toggle.checked); };
+      const apply = ()=>{
+        mount.classList.toggle('hidden', !toggle.checked);
+        if(toggle.checked){
+          // Best-effort: if turning on and UI is missing, initialize IE lazily
+          ensureIEReady();
+        }
+      };
       toggle.addEventListener('change', apply);
       // If the toggle is already checked (e.g., restored state), reflect it
       apply();

--- a/public/styles.css
+++ b/public/styles.css
@@ -777,6 +777,10 @@ body.is-quiz .hero{ /* transform: scale(.96); opacity:.9; */ }
 /* Drag state */
 .ie-card.drag-over{ outline:2px dashed var(--border) }
 .ie-toolbar .flex-spacer{ flex:1 1 0 }
+body[data-theme="dark"] .ie-toolbar .btn:focus-visible,
+body[data-theme="dark"] .ie-grid .btn:focus-visible{
+  box-shadow:none;
+}
 
 /* Ensure .hidden truly hides even with inline tweaks */
 .hidden{ display: none !important }

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v123';
+const CACHE_NAME = 'ezquiz-cache-v124';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -24,7 +24,7 @@ const RELATIVE_URLS = [
   'styles.css?v=1.5.5',
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
-  'js/patches.js?v=1.5.7',
+  'js/patches.js?v=1.5.8',
   'js/editor.gui.js?v=1.5.17',
   'manifest.webmanifest',
   'sw.js',

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v119';
+const CACHE_NAME = 'ezquiz-cache-v120';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -24,7 +24,7 @@ const RELATIVE_URLS = [
   'styles.css?v=1.5.5',
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
-  'js/patches.js?v=1.5.3',
+  'js/patches.js?v=1.5.4',
   'js/editor.gui.js?v=1.5.17',
   'manifest.webmanifest',
   'sw.js',

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v121';
+const CACHE_NAME = 'ezquiz-cache-v122';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -24,7 +24,7 @@ const RELATIVE_URLS = [
   'styles.css?v=1.5.5',
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
-  'js/patches.js?v=1.5.5',
+  'js/patches.js?v=1.5.6',
   'js/editor.gui.js?v=1.5.17',
   'manifest.webmanifest',
   'sw.js',

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v120';
+const CACHE_NAME = 'ezquiz-cache-v121';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -24,7 +24,7 @@ const RELATIVE_URLS = [
   'styles.css?v=1.5.5',
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
-  'js/patches.js?v=1.5.4',
+  'js/patches.js?v=1.5.5',
   'js/editor.gui.js?v=1.5.17',
   'manifest.webmanifest',
   'sw.js',

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v122';
+const CACHE_NAME = 'ezquiz-cache-v123';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -24,7 +24,7 @@ const RELATIVE_URLS = [
   'styles.css?v=1.5.5',
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
-  'js/patches.js?v=1.5.6',
+  'js/patches.js?v=1.5.7',
   'js/editor.gui.js?v=1.5.17',
   'manifest.webmanifest',
   'sw.js',

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v124';
+const CACHE_NAME = 'ezquiz-cache-v125';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -25,7 +25,7 @@ const RELATIVE_URLS = [
   'js/main.js?v=1.5.6',
   'js/auto-refresh.js?v=1.5.2',
   'js/patches.js?v=1.5.8',
-  'js/editor.gui.js?v=1.5.17',
+  'js/editor.gui.js?v=1.5.18',
   'manifest.webmanifest',
   'sw.js',
   'icons/icon-192.png',


### PR DESCRIPTION
## Summary
- remove the theme radio controls from the generator options dropdown so theme selection lives only in the settings modal
- stop the generator script from wiring theme radio elements that no longer exist
- turn off the dark-theme focus glow on Interactive Editor buttons to avoid the unintended effect
- update the help modal copy so it references the settings location for theme selection
- refresh the changelog, release notes, and README so documentation matches the relocated theme controls

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68ce2982fc70832990a8743cff0d002f