### PR TITLE
Polish generator toolbar and quiz editor UI

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -29,6 +29,6 @@ Hey future helper! This repo ships the [ez-quiz.app](https://ez-quiz.app) PWA pl
 
 - 2025-09-19 — Added mobile comfort pass (length/difficulty pairing, IE toggle spacing) and refreshed cache-buster (v1.5.10). Veil strings restored; spinner hides cleanly on “Done”.
 - 2025-09-23 — Synced AI generation with the Interactive Editor. Generator now dispatches input events so IE cards refresh automatically when quizzes load.
-- 2025-09-23 — Refined the generator toolbar layout and refreshed Quiz Editor panes for better responsiveness and visual polish.
+- 2025-09-24 — Rebalanced the generator toolbar with a responsive grid polish and wrapped the Quiz Editor panes with headers/gradients for clearer context across breakpoints.
 
 — Codex (GPT-5), 2025-02-14

--- a/agents.md
+++ b/agents.md
@@ -29,5 +29,6 @@ Hey future helper! This repo ships the [ez-quiz.app](https://ez-quiz.app) PWA pl
 
 - 2025-09-19 — Added mobile comfort pass (length/difficulty pairing, IE toggle spacing) and refreshed cache-buster (v1.5.10). Veil strings restored; spinner hides cleanly on “Done”.
 - 2025-09-23 — Synced AI generation with the Interactive Editor. Generator now dispatches input events so IE cards refresh automatically when quizzes load.
+- 2025-09-23 — Refined the generator toolbar layout and refreshed Quiz Editor panes for better responsiveness and visual polish.
 
 — Codex (GPT-5), 2025-02-14

--- a/public/index.html
+++ b/public/index.html
@@ -38,11 +38,11 @@
 
       <!-- Top toolbar (simple generate form) -->
       <div class="gen-toolbar" role="group" aria-label="Generate toolbar">
-        <label class="toolbar-field topic-field">
+        <label class="toolbar-field">
           <span class="toolbar-label">Topic</span>
           <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
         </label>
-        <div class="difficulty-field">
+        <div class="toolbar-pair">
           <div class="difficulty-stack">
             <label for="difficultySlider" class="difficulty-label">Difficulty</label>
             <div class="difficulty-slider">
@@ -54,21 +54,19 @@
               <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
             </div>
           </div>
-        </div>
-        <label class="toolbar-field narrow number-field length-field">
-          <span class="toolbar-label">Length</span>
-          <div class="number-wrap">
-            <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
-            <div class="stepper-group" role="group" aria-label="Adjust length">
-              <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
-              <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
+          <label class="toolbar-field narrow number-field">
+            <span class="toolbar-label">Length</span>
+            <div class="number-wrap">
+              <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
+              <div class="stepper-group" role="group" aria-label="Adjust length">
+                <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
+                <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
+              </div>
             </div>
-          </div>
-        </label>
-        <div class="toolbar-actions">
-          <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
-          <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
+          </label>
         </div>
+        <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
+        <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
       </div>
 
       <!-- Options Drop-Down (includes Quiz Editor tools) -->
@@ -118,37 +116,11 @@
           <div id="interactiveEditor" aria-live="polite"></div>
           <div class="adv-panels" data-editor-panels>
             <div class="adv-left" data-editor-panel="manual" hidden>
-              <div class="editor-pane" data-pane="manual">
-                <div class="editor-pane__header">
-                  <span id="manualPaneTitle" class="editor-pane__title">Manual input</span>
-                  <span id="manualPaneHint" class="editor-pane__hint">Paste or type quiz lines</span>
-                </div>
-                <textarea
-                  id="editor"
-                  class="editor"
-                  rows="12"
-                  aria-labelledby="manualPaneTitle"
-                  aria-describedby="manualPaneHint"
-                  placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
-              </div>
+              <textarea id="editor" class="editor" rows="12" placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
             </div>
             <div class="adv-right">
-              <div class="editor-pane" data-pane="mirror">
-                <div class="editor-pane__header">
-                  <span id="mirrorPaneTitle" class="editor-pane__title">Mirror preview</span>
-                  <span id="mirrorPaneHint" class="editor-pane__hint">Auto-updates from Generate</span>
-                </div>
-                <div id="mirrorBox" class="mirror-box" data-on="false" data-empty="true">
-                  <textarea
-                    id="mirror"
-                    class="mirror"
-                    rows="12"
-                    readonly
-                    aria-label="Generated quiz lines (read-only)"
-                    aria-labelledby="mirrorPaneTitle"
-                    aria-describedby="mirrorPaneHint"
-                    data-empty="true"></textarea>
-                </div>
+              <div id="mirrorBox" class="mirror-box" data-on="false" data-empty="true">
+                <textarea id="mirror" class="mirror" rows="12" readonly aria-label="Generated quiz lines (read-only)" data-empty="true"></textarea>
               </div>
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
   <main class="container" id="app" role="main">
     <!-- Generator Card -->
     <section id="generatorCard" class="card">
-      <div id="updateBanner" class="update-banner hidden" role="status" aria-live="polite">
+      <div id="updateBanner" class="update-banner hidden" hidden role="status" aria-live="polite">
         <span>Update available. Refresh to apply.</span>
         <span class="flex-spacer"></span>
         <button id="updateRefreshBtn" class="btn primary" type="button">Refresh</button>

--- a/public/index.html
+++ b/public/index.html
@@ -38,39 +38,35 @@
 
       <!-- Top toolbar (simple generate form) -->
       <div class="gen-toolbar" role="group" aria-label="Generate toolbar">
-        <div class="gen-toolbar__layout">
-          <label class="toolbar-field topic-field">
-            <span class="toolbar-label">Topic</span>
-            <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
-          </label>
-          <div class="toolbar-duo">
-            <div class="difficulty-stack">
-              <label for="difficultySlider" class="difficulty-label">Difficulty</label>
-              <div class="difficulty-slider">
-                <div class="difficulty-track" aria-hidden="true">
-                  <span class="difficulty-dot"></span>
-                  <span class="difficulty-dot"></span>
-                  <span class="difficulty-dot"></span>
-                </div>
-                <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
+        <label class="toolbar-field">
+          <span class="toolbar-label">Topic</span>
+          <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
+        </label>
+        <div class="toolbar-pair">
+          <div class="difficulty-stack">
+            <label for="difficultySlider" class="difficulty-label">Difficulty</label>
+            <div class="difficulty-slider">
+              <div class="difficulty-track" aria-hidden="true">
+                <span class="difficulty-dot"></span>
+                <span class="difficulty-dot"></span>
+                <span class="difficulty-dot"></span>
+              </div>
+              <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
+            </div>
+          </div>
+          <label class="toolbar-field narrow number-field">
+            <span class="toolbar-label">Length</span>
+            <div class="number-wrap">
+              <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
+              <div class="stepper-group" role="group" aria-label="Adjust length">
+                <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
+                <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
               </div>
             </div>
-            <label class="toolbar-field number-field">
-              <span class="toolbar-label">Length</span>
-              <div class="number-wrap">
-                <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
-                <div class="stepper-group" role="group" aria-label="Adjust length">
-                  <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
-                  <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
-                </div>
-              </div>
-            </label>
-          </div>
-          <div class="toolbar-actions" role="group" aria-label="Generator actions">
-            <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
-            <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
-          </div>
+          </label>
         </div>
+        <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
+        <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
       </div>
 
       <!-- Options Drop-Down (includes Quiz Editor tools) -->
@@ -120,22 +116,36 @@
           <div id="interactiveEditor" aria-live="polite"></div>
           <div class="adv-panels" data-editor-panels>
             <div class="adv-left" data-editor-panel="manual" hidden>
-              <div class="ie-pane" data-pane="manual">
-                <div class="ie-pane__header">
-                  <span class="ie-pane__title">Manual input</span>
-                  <span class="ie-pane__hint">Paste or type quiz lines</span>
+              <div class="editor-pane" data-pane="manual">
+                <div class="editor-pane__header">
+                  <span id="manualPaneTitle" class="editor-pane__title">Manual input</span>
+                  <span id="manualPaneHint" class="editor-pane__hint">Paste or type quiz lines</span>
                 </div>
-                <textarea id="editor" class="editor" rows="12" placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
+                <textarea
+                  id="editor"
+                  class="editor"
+                  rows="12"
+                  aria-labelledby="manualPaneTitle"
+                  aria-describedby="manualPaneHint"
+                  placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
               </div>
             </div>
             <div class="adv-right">
-              <div class="ie-pane" data-pane="mirror">
-                <div class="ie-pane__header">
-                  <span class="ie-pane__title">Mirror preview</span>
-                  <span class="ie-pane__hint">Auto-updates from Generate</span>
+              <div class="editor-pane" data-pane="mirror">
+                <div class="editor-pane__header">
+                  <span id="mirrorPaneTitle" class="editor-pane__title">Mirror preview</span>
+                  <span id="mirrorPaneHint" class="editor-pane__hint">Auto-updates from Generate</span>
                 </div>
                 <div id="mirrorBox" class="mirror-box" data-on="false" data-empty="true">
-                  <textarea id="mirror" class="mirror" rows="12" readonly aria-label="Generated quiz lines (read-only)" data-empty="true"></textarea>
+                  <textarea
+                    id="mirror"
+                    class="mirror"
+                    rows="12"
+                    readonly
+                    aria-label="Generated quiz lines (read-only)"
+                    aria-labelledby="mirrorPaneTitle"
+                    aria-describedby="mirrorPaneHint"
+                    data-empty="true"></textarea>
                 </div>
               </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -38,35 +38,39 @@
 
       <!-- Top toolbar (simple generate form) -->
       <div class="gen-toolbar" role="group" aria-label="Generate toolbar">
-        <label class="toolbar-field">
-          <span class="toolbar-label">Topic</span>
-          <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
-        </label>
-        <div class="toolbar-pair">
-          <div class="difficulty-stack">
-            <label for="difficultySlider" class="difficulty-label">Difficulty</label>
-            <div class="difficulty-slider">
-              <div class="difficulty-track" aria-hidden="true">
-                <span class="difficulty-dot"></span>
-                <span class="difficulty-dot"></span>
-                <span class="difficulty-dot"></span>
-              </div>
-              <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
-            </div>
-          </div>
-          <label class="toolbar-field narrow number-field">
-            <span class="toolbar-label">Length</span>
-            <div class="number-wrap">
-              <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
-              <div class="stepper-group" role="group" aria-label="Adjust length">
-                <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
-                <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
-              </div>
-            </div>
+        <div class="gen-toolbar__layout">
+          <label class="toolbar-field topic-field">
+            <span class="toolbar-label">Topic</span>
+            <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
           </label>
+          <div class="toolbar-duo">
+            <div class="difficulty-stack">
+              <label for="difficultySlider" class="difficulty-label">Difficulty</label>
+              <div class="difficulty-slider">
+                <div class="difficulty-track" aria-hidden="true">
+                  <span class="difficulty-dot"></span>
+                  <span class="difficulty-dot"></span>
+                  <span class="difficulty-dot"></span>
+                </div>
+                <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
+              </div>
+            </div>
+            <label class="toolbar-field number-field">
+              <span class="toolbar-label">Length</span>
+              <div class="number-wrap">
+                <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
+                <div class="stepper-group" role="group" aria-label="Adjust length">
+                  <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
+                  <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
+                </div>
+              </div>
+            </label>
+          </div>
+          <div class="toolbar-actions" role="group" aria-label="Generator actions">
+            <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
+            <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
+          </div>
         </div>
-        <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
-        <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
       </div>
 
       <!-- Options Drop-Down (includes Quiz Editor tools) -->
@@ -116,11 +120,23 @@
           <div id="interactiveEditor" aria-live="polite"></div>
           <div class="adv-panels" data-editor-panels>
             <div class="adv-left" data-editor-panel="manual" hidden>
-              <textarea id="editor" class="editor" rows="12" placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
+              <div class="ie-pane" data-pane="manual">
+                <div class="ie-pane__header">
+                  <span class="ie-pane__title">Manual input</span>
+                  <span class="ie-pane__hint">Paste or type quiz lines</span>
+                </div>
+                <textarea id="editor" class="editor" rows="12" placeholder="MC|Question?|A) 1;B) 2|A&#10;TF|Statement.|T&#10;YN|Question?|Y&#10;MT|Match.|1) L1;2) L2|A) R1;B) R2|1-A,2-B"></textarea>
+              </div>
             </div>
             <div class="adv-right">
-              <div id="mirrorBox" class="mirror-box" data-on="false" data-empty="true">
-                <textarea id="mirror" class="mirror" rows="12" readonly aria-label="Generated quiz lines (read-only)" data-empty="true"></textarea>
+              <div class="ie-pane" data-pane="mirror">
+                <div class="ie-pane__header">
+                  <span class="ie-pane__title">Mirror preview</span>
+                  <span class="ie-pane__hint">Auto-updates from Generate</span>
+                </div>
+                <div id="mirrorBox" class="mirror-box" data-on="false" data-empty="true">
+                  <textarea id="mirror" class="mirror" rows="12" readonly aria-label="Generated quiz lines (read-only)" data-empty="true"></textarea>
+                </div>
               </div>
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -38,11 +38,11 @@
 
       <!-- Top toolbar (simple generate form) -->
       <div class="gen-toolbar" role="group" aria-label="Generate toolbar">
-        <label class="toolbar-field">
+        <label class="toolbar-field topic-field">
           <span class="toolbar-label">Topic</span>
           <input id="topicInput" type="text" class="toolbar-input" placeholder="e.g. Animals" />
         </label>
-        <div class="toolbar-pair">
+        <div class="difficulty-field">
           <div class="difficulty-stack">
             <label for="difficultySlider" class="difficulty-label">Difficulty</label>
             <div class="difficulty-slider">
@@ -54,19 +54,21 @@
               <input id="difficultySlider" type="range" min="0" max="4" step="1" value="2" aria-valuetext="Medium" />
             </div>
           </div>
-          <label class="toolbar-field narrow number-field">
-            <span class="toolbar-label">Length</span>
-            <div class="number-wrap">
-              <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
-              <div class="stepper-group" role="group" aria-label="Adjust length">
-                <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
-                <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
-              </div>
-            </div>
-          </label>
         </div>
-        <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
-        <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
+        <label class="toolbar-field narrow number-field length-field">
+          <span class="toolbar-label">Length</span>
+          <div class="number-wrap">
+            <input id="countInput" type="number" class="toolbar-input" min="1" step="1" value="10" />
+            <div class="stepper-group" role="group" aria-label="Adjust length">
+              <button type="button" class="stepper stepper-up" data-step="up" aria-label="Increase length">▲</button>
+              <button type="button" class="stepper stepper-down" data-step="down" aria-label="Decrease length">▼</button>
+            </div>
+          </div>
+        </label>
+        <div class="toolbar-actions">
+          <button id="generateBtn" class="btn primary" aria-label="Generate only (fills editor and mirror)">Generate</button>
+          <button id="optionsBtn" class="btn" aria-haspopup="true" aria-expanded="false" aria-controls="optionsPanel">Options ▾</button>
+        </div>
       </div>
 
       <!-- Options Drop-Down (includes Quiz Editor tools) -->

--- a/public/js/editor.gui.js
+++ b/public/js/editor.gui.js
@@ -226,7 +226,8 @@ const IE2 = (()=>{
     document.addEventListener('keydown', (e)=>{
       if(!state.enabled) return;
       if(e.ctrlKey||e.metaKey||e.altKey) return;
-      const k=e.key.toLowerCase();
+      const k = (typeof e.key === 'string') ? e.key.toLowerCase() : '';
+      if(!k) return;
       if(k==='m'){
         e.preventDefault();
         addQ(e.shiftKey?'MT':'MC');

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -18,7 +18,10 @@ export function showUpdateBannerIfReady(){
     const flag = localStorage.getItem('ezq.update.ready');
     if(flag === '1'){
       const banner = document.getElementById('updateBanner');
-      if(banner){ banner.classList.remove('hidden'); }
+      if(banner){
+        banner.classList.remove('hidden');
+        banner.hidden = false;
+      }
     }
   }catch{}
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,8 +22,9 @@
   --field-hover:#121a27;
   --focus-shadow:0 0 0 3px rgba(126, 163, 255, .35);
   --radius-lg:20px;
-  --toolbar-glow:rgba(122, 162, 255, .16);
-  --editor-glow:rgba(122, 162, 255, .12);
+  --radius-card:8px;
+  --radius-control:8px;
+  --shadow-card:0 2px 8px rgba(0,0,0,.25);
   --space-1:6px;
   --space-2:10px;
   --space-3:12px;
@@ -49,8 +50,7 @@ body[data-theme="light"]{
   --field-border:#cfd8ea;
   --field-hover:#e8edf6;
   --focus-shadow:0 0 0 3px rgba(110, 163, 255, .35);
-  --toolbar-glow:rgba(36, 92, 255, .12);
-  --editor-glow:rgba(36, 92, 255, .08);
+  --shadow-card:0 2px 8px rgba(15,23,42,.18);
 }
 
 *{box-sizing:border-box}
@@ -85,7 +85,7 @@ body[data-theme="light"] .brand-logo{
 .header-actions{display:flex; gap:10px}
 .icon-btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); border-radius:8px; padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
+  color:var(--text); border-radius:var(--radius-control); padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease;
 }
 .icon-btn:hover{filter:brightness(1.06)}
@@ -113,10 +113,10 @@ body[data-theme="dark"] .site-header .brand-link{
 .card{
   background:var(--panel);
   border:1px solid var(--border);
-  border-radius:8px;
+  border-radius:var(--radius-card);
   padding:16px;
   margin-bottom:16px;
-  box-shadow:0 2px 10px rgba(0,0,0,.25);
+  box-shadow:var(--shadow-card);
 }
 /* Keep quiz runner comfortably large on desktop */
 @media (min-width: 900px){
@@ -131,131 +131,116 @@ body[data-theme="dark"] .site-header .brand-link{
 
 /* Generate toolbar */
 .gen-toolbar{
-  --toolbar-control-height:clamp(40px, 4vw, 44px);
+  --toolbar-control-height:clamp(40px, 3.5vw, 44px);
   display:grid;
-  grid-template-columns:1fr auto auto auto;
+  grid-template-columns:minmax(0,1fr) minmax(220px,1fr) minmax(96px,auto) auto auto;
   align-items:center;
   gap:var(--space-3);
-  background:linear-gradient(180deg, rgba(21,25,37,.98), rgba(21,25,37,.94));
+  background:linear-gradient(180deg, rgba(21,25,37,.98), rgba(21,25,37,.92));
   border:1px solid var(--field-border);
-  border-radius:8px;
-  padding:var(--space-3) calc(var(--space-3) + 4px);
-  margin-inline:auto;
-  margin-block-end:16px;
+  border-radius:var(--radius-card);
+  padding:var(--space-3);
+  margin:0 auto 16px;
   max-width:960px;
-  box-shadow:0 2px 10px rgba(0,0,0,.25);
+  box-shadow:var(--shadow-card);
   grid-auto-rows:minmax(var(--toolbar-control-height), auto);
 }
 body[data-theme="light"] .gen-toolbar{
   background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(244,248,254,.94));
   border-color:var(--border);
-  box-shadow:0 2px 10px rgba(0,0,0,.2);
+  box-shadow:0 2px 8px rgba(15,23,42,.16);
 }
 .gen-toolbar > *{ min-width:0; }
-.gen-toolbar .topic-field{
-  min-width:260px;
-  max-width:360px;
-  width:100%;
+.gen-toolbar > .toolbar-field{ min-width:260px; }
+.gen-toolbar .toolbar-pair{
+  grid-column:2 / 4;
+  display:grid;
+  grid-template-columns:minmax(220px,1fr) minmax(96px,auto);
+  gap:var(--space-3);
+  align-items:stretch;
+  min-width:0;
 }
-.gen-toolbar .difficulty-field{
-  min-width:220px;
-  width:100%;
-}
-.gen-toolbar .length-field{
-  min-width:96px;
-  width:100%;
-}
-.gen-toolbar .toolbar-actions{
-  display:flex;
-  align-items:center;
-  justify-content:flex-end;
-  flex-wrap:wrap;
-  gap:8px;
-  justify-self:end;
-}
-.gen-toolbar .toolbar-actions .btn{
+.gen-toolbar .difficulty-stack{ min-width:220px; }
+.gen-toolbar .number-field{ min-width:96px; }
+.gen-toolbar #generateBtn,
+.gen-toolbar #optionsBtn{
   min-height:var(--toolbar-control-height);
-  padding:6px 10px;
+  padding:6px 12px;
   font-size:.9rem;
-  border-radius:8px;
-  min-width:120px;
-  transition:filter .15s ease, box-shadow .2s ease;
+  border-radius:var(--radius-control);
+  justify-self:end;
+  align-self:stretch;
+  min-width:128px;
 }
-.gen-toolbar .toolbar-actions .btn:hover{
-  filter:brightness(1.06);
-  box-shadow:0 6px 16px rgba(5, 8, 17, .24);
-}
-.gen-toolbar .toolbar-actions .btn:active{
-  filter:brightness(.96);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
-}
-.gen-toolbar .toolbar-actions .btn:focus-visible{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
-  box-shadow:var(--focus-shadow);
-}
+.gen-toolbar #generateBtn{ grid-column:4; }
+.gen-toolbar #optionsBtn{ grid-column:5; }
+
 @media (max-width:1024px){
   .gen-toolbar{
-    grid-template-columns:1fr auto auto;
-    align-items:end;
+    grid-template-columns:minmax(0,1fr) minmax(220px,1fr) auto;
+    grid-auto-rows:minmax(var(--toolbar-control-height), auto);
     row-gap:var(--space-2);
   }
-  .gen-toolbar .toolbar-actions{
-    grid-column:1 / -1;
-    justify-self:end;
-  }
+  .gen-toolbar .toolbar-pair{ grid-column:2; }
+  .gen-toolbar #generateBtn{ grid-column:3; }
+  .gen-toolbar #optionsBtn{ grid-column:3; grid-row:2; }
 }
+
 @media (max-width:720px){
   .gen-toolbar{
     grid-template-columns:1fr;
-    align-items:stretch;
     padding:var(--space-3);
   }
-  .gen-toolbar .toolbar-actions{
-    justify-content:flex-end;
-    width:100%;
+  .gen-toolbar > .toolbar-field{ min-width:0; }
+  .gen-toolbar .toolbar-pair{
+    grid-column:1;
+    grid-template-columns:1fr;
+  }
+  .gen-toolbar .difficulty-stack,
+  .gen-toolbar .number-field{ min-width:0; }
+  .gen-toolbar #generateBtn,
+  .gen-toolbar #optionsBtn{
+    grid-column:1;
+    grid-row:auto;
+    justify-self:stretch;
+    min-width:0;
   }
 }
+
 @media (max-width:480px){
-  .gen-toolbar .toolbar-actions{
-    justify-content:stretch;
+  .gen-toolbar{
+    gap:var(--space-2);
   }
-  .gen-toolbar .toolbar-actions .btn{
-    flex:1 1 100%;
-    min-width:0;
+  .gen-toolbar #generateBtn,
+  .gen-toolbar #optionsBtn{
+    width:100%;
   }
 }
 .toolbar-field{
   position:relative;
   display:flex;
-  align-items:center;
+  flex-direction:column;
+  gap:var(--space-2);
+  align-items:stretch;
   flex:1 1 auto;
-  min-width:160px;
-  min-height:calc(var(--toolbar-control-height, 44px) + var(--space-2));
-  padding:var(--space-3) 10px var(--space-2);
-  width:100%;
+  padding-top:var(--space-3);
 }
-.toolbar-field > .toolbar-input{
-  flex:1 1 auto;
-  width:100%;
-}
-.toolbar-field.narrow{ flex:1 1 150px; min-width:120px; }
+.toolbar-field.narrow{ flex:0 0 auto; }
 .toolbar-label{
   position:absolute;
   top:-10px;
-  left:10px;
+  left:12px;
   padding:2px 8px;
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:var(--panel);
   border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
-  color:var(--muted);
   letter-spacing:.05em;
-  line-height:1;
   text-transform:uppercase;
+  line-height:1;
+  color:var(--muted);
   text-align:left;
-  z-index:1;
   pointer-events:none;
   box-shadow:0 1px 2px rgba(0,0,0,.28);
 }
@@ -268,11 +253,11 @@ body[data-theme="light"] .toolbar-label{
   border:1px solid var(--field-border);
   background:var(--panel-2);
   color:var(--text);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   min-height:var(--toolbar-control-height);
   padding:10px 12px;
   font-size:.9rem;
-  transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
+  transition:background .18s ease, border-color .18s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .toolbar-input{
   background:var(--panel);
@@ -286,10 +271,6 @@ body[data-theme="light"] .toolbar-input{
   outline-offset:2px;
   box-shadow:var(--focus-shadow);
 }
-.toolbar-field:focus-within .toolbar-label,
-.difficulty-stack:focus-within .difficulty-label{
-  color:var(--text);
-}
 .gen-toolbar #countInput{ text-align:center; }
 .number-wrap{
   position:relative;
@@ -298,14 +279,12 @@ body[data-theme="light"] .toolbar-input{
   align-items:stretch;
   border:1px solid var(--field-border);
   background:var(--panel-2);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   overflow:hidden;
-  transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
+  transition:background .18s ease, border-color .18s ease, box-shadow .2s ease;
   min-height:var(--toolbar-control-height);
 }
-body[data-theme="light"] .number-wrap{
-  background:var(--panel);
-}
+body[data-theme="light"] .number-wrap{ background:var(--panel); }
 .number-wrap:hover{
   background:var(--field-hover);
   border-color:var(--border);
@@ -320,9 +299,10 @@ body[data-theme="light"] .number-wrap{
   width:100%;
   border:0;
   background:transparent;
-  padding:10px 12px;
+  padding:0 12px;
   min-height:var(--toolbar-control-height);
   color:var(--text);
+  font-size:.9rem;
   box-shadow:none;
 }
 .number-wrap .toolbar-input:hover,
@@ -346,29 +326,28 @@ body[data-theme="light"] .number-wrap{
   width:26px;
   border-left:1px solid var(--field-border);
   background:var(--panel-2);
-  min-height:var(--toolbar-control-height);
 }
 .stepper{
   flex:1 1 50%;
   border:0;
   background:transparent;
   color:var(--muted);
-  font-size:.58rem;
+  font-size:.6rem;
   font-weight:600;
+  letter-spacing:.08em;
   line-height:1;
   display:flex;
   align-items:center;
   justify-content:center;
   cursor:pointer;
-  letter-spacing:.08em;
   transition:background .12s ease, color .12s ease;
 }
 .stepper:first-child{
   border-bottom:1px solid var(--field-border);
-  border-top-right-radius:8px;
+  border-top-right-radius:var(--radius-control);
 }
 .stepper:last-child{
-  border-bottom-right-radius:8px;
+  border-bottom-right-radius:var(--radius-control);
 }
 .stepper:hover{
   background:var(--field-hover);
@@ -385,43 +364,36 @@ body[data-theme="light"] .number-wrap{
 .difficulty-stack{
   position:relative;
   display:flex;
-  align-items:center;
+  flex-direction:column;
   justify-content:center;
-  flex:1 1 auto;
-  min-width:220px;
-  min-height:calc(var(--toolbar-control-height, 44px) + var(--space-2));
-  padding:var(--space-3) 10px var(--space-2);
-  border-radius:8px;
+  gap:var(--space-2);
+  padding:var(--space-3) 12px var(--space-2);
+  border-radius:var(--radius-control);
   background:var(--panel-2);
   border:1px solid var(--field-border);
-  transition:border-color .15s ease, box-shadow .2s ease, background .15s ease;
-  width:100%;
+  min-height:calc(var(--toolbar-control-height) + var(--space-2));
+  transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-stack{
-  background:var(--panel);
-}
+body[data-theme="light"] .difficulty-stack{ background:var(--panel); }
 .difficulty-stack:hover{ border-color:var(--border); }
 .difficulty-stack:focus-within{
   border-color:var(--ring);
   box-shadow:var(--focus-shadow);
 }
-.difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
   top:-10px;
-  left:10px;
+  left:12px;
   padding:2px 8px;
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:var(--panel);
   border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
-  color:var(--muted);
   letter-spacing:.05em;
-  line-height:1;
   text-transform:uppercase;
-  text-align:left;
-  z-index:1;
+  line-height:1;
+  color:var(--muted);
   pointer-events:none;
   box-shadow:0 1px 2px rgba(0,0,0,.28);
 }
@@ -431,7 +403,7 @@ body[data-theme="light"] .difficulty-label{
   box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .difficulty-slider{
-  --thumb-size:clamp(16px, 3.6vw, 18px);
+  --thumb-size:clamp(16px, 3.4vw, 18px);
   --track-height:2px;
   --dot-size:4px;
   position:relative;
@@ -470,31 +442,35 @@ body[data-theme="light"] .difficulty-label{
   border-radius:50%;
   background:var(--primary);
   border:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.35);
+  box-shadow:0 1px 2px rgba(0,0,0,.4);
   margin-top:calc((var(--track-height) - var(--thumb-size)) / 2);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.2); }
+body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{
+  box-shadow:0 1px 2px rgba(0,0,0,.25);
+}
 .difficulty-slider input[type="range"]::-moz-range-thumb{
   width:var(--thumb-size);
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
   border:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.35);
+  box-shadow:0 1px 2px rgba(0,0,0,.4);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.2); }
+body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{
+  box-shadow:0 1px 2px rgba(0,0,0,.25);
+}
 .difficulty-slider input[type="range"]:focus{ outline:none; }
 .difficulty-slider input[type="range"]:focus-visible::-webkit-slider-thumb{
-  box-shadow:0 0 0 2px rgba(122,162,255,.45), 0 1px 2px rgba(0,0,0,.35);
+  box-shadow:0 0 0 2px color-mix(in oklab, var(--brand) 60%, transparent), 0 1px 2px rgba(0,0,0,.4);
 }
 .difficulty-slider input[type="range"]:focus-visible::-moz-range-thumb{
-  box-shadow:0 0 0 2px rgba(122,162,255,.45), 0 1px 2px rgba(0,0,0,.35);
+  box-shadow:0 0 0 2px color-mix(in oklab, var(--brand) 60%, transparent), 0 1px 2px rgba(0,0,0,.4);
 }
 .difficulty-slider input[type="range"]:active::-webkit-slider-thumb,
 .difficulty-slider input[type="range"]:active::-moz-range-thumb{
-  box-shadow:inset 0 0 0 1px rgba(0,0,0,.18), 0 1px 2px rgba(0,0,0,.35);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.18), 0 1px 2px rgba(0,0,0,.4);
 }
 .difficulty-track{
   position:absolute;
@@ -504,19 +480,17 @@ body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thum
   height:var(--track-height);
   transform:translateY(-50%);
   pointer-events:none;
-  background:rgba(122,162,255,.22);
+  background:rgba(122,162,255,.28);
   border-radius:999px;
   transition:background .2s ease;
 }
-body[data-theme="light"] .difficulty-track{
-  background:rgba(36,92,255,.18);
-}
+body[data-theme="light"] .difficulty-track{ background:rgba(36,92,255,.2); }
 .difficulty-slider:hover .difficulty-track,
 .difficulty-stack:focus-within .difficulty-track{
-  background:rgba(122,162,255,.35);
+  background:rgba(122,162,255,.4);
 }
-body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track,
-body[data-theme="light"] .difficulty-slider:hover .difficulty-track{
+body[data-theme="light"] .difficulty-slider:hover .difficulty-track,
+body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track{
   background:rgba(36,92,255,.32);
 }
 .difficulty-dot{
@@ -525,10 +499,9 @@ body[data-theme="light"] .difficulty-slider:hover .difficulty-track{
   width:var(--dot-size);
   height:var(--dot-size);
   border-radius:50%;
-  background:rgba(255,255,255,.38);
+  background:var(--field-border);
   transform:translate(-50%, -50%);
 }
-body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .difficulty-track .difficulty-dot:nth-child(1){ left:25%; }
 .difficulty-track .difficulty-dot:nth-child(2){ left:50%; }
 .difficulty-track .difficulty-dot:nth-child(3){ left:75%; }
@@ -536,52 +509,49 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 
 /* Options panel (drop-down) */
 .options-panel{
-  margin:8px auto 0; max-width:960px;
-  border:1px solid var(--field-border); background:var(--panel-2); border-radius:8px;
-  padding:10px; box-shadow:0 2px 10px rgba(0,0,0,.25);
+  margin:12px auto 0;
+  max-width:960px;
+  border:1px solid var(--field-border);
+  background:var(--panel-2);
+  border-radius:var(--radius-card);
+  padding:var(--space-3);
+  box-shadow:var(--shadow-card);
   transition:opacity .2s ease, transform .2s ease;
 }
 .options-panel[hidden]{display:none}
 .options-regular .lbl{color:var(--muted); font-size:14px}
-.opt-switch{display:inline-flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid var(--field-border); background:var(--panel); border-radius:999px}
+.opt-switch{display:inline-flex; align-items:center; gap:var(--space-1); padding:6px 10px; border:1px solid var(--field-border); background:var(--panel); border-radius:var(--radius-control)}
 .opt-switch input{transform:scale(1)}
-.mirror-toggle{gap:12px; padding:6px 12px; background:var(--panel-2); border-color:var(--field-border); justify-content:space-between; min-width:0;}
+.mirror-toggle{gap:12px; padding:6px 12px; background:var(--panel-2); border-color:var(--field-border); justify-content:space-between; min-width:0; border-radius:var(--radius-control);}
 .mirror-toggle-label{font-size:.8rem; font-weight:600; color:var(--muted); text-transform:none;}
 .mirror-toggle input{transform:scale(0.95); margin-left:4px;}
 .inline.small-field input{min-width:96px}
 .muted.small{color:var(--muted); font-size:.9em}
-.divider{height:1px; background:var(--border); margin:10px -10px}
-.advanced-disclosure{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; cursor:pointer; border-radius:8px}
+.divider{height:1px; background:var(--border); margin:var(--space-3) calc(var(--space-3) * -1)}
+.advanced-disclosure{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; cursor:pointer; border-radius:var(--radius-control)}
 .advanced-disclosure:focus-visible{outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow)}
 .advanced-disclosure:hover{background:var(--field-hover)}
 .advanced-disclosure .caret{display:inline-block; transition:transform .18s ease}
 .advanced-disclosure[aria-expanded="true"] .caret{transform:rotate(-180deg)}
-.advanced-body{padding:10px; background:var(--panel-2); border-radius:8px; animation:fadeSlide .22s ease}
+.advanced-body{padding:var(--space-3); background:var(--panel-2); border-radius:var(--radius-card); animation:fadeSlide .22s ease}
 @keyframes fadeSlide{from{opacity:0; transform:translateY(-4px)} to{opacity:1; transform:none}}
 .row.wrap{flex-wrap:wrap}
 
 /* Quiz Editor: side-by-side editor + mirror */
 .adv-head{display:grid; grid-template-columns: auto 1fr; align-items:center; gap:12px; margin-bottom:8px}
-.adv-mode-toggle{display:inline-flex; align-items:center; gap:4px; padding:4px; background:var(--panel-2); border:1px solid var(--field-border); border-radius:999px; box-shadow:var(--shadow-xs);}
-.adv-mode-btn{border:0; background:transparent; color:var(--muted); font-weight:600; padding:6px 14px; border-radius:999px; cursor:pointer; transition:background .15s ease, color .15s ease, box-shadow .15s ease;}
+.adv-mode-toggle{display:inline-flex; align-items:center; gap:4px; padding:4px; background:var(--panel-2); border:1px solid var(--field-border); border-radius:var(--radius-control); box-shadow:none;}
+.adv-mode-btn{border:0; background:transparent; color:var(--muted); font-weight:600; padding:6px 14px; border-radius:var(--radius-control); cursor:pointer; transition:background .15s ease, color .15s ease, box-shadow .15s ease;}
 .adv-mode-btn:is(:hover,:focus-visible){color:var(--text);}
 .adv-mode-btn:focus-visible{outline:2px solid var(--ring); outline-offset:2px;}
-.adv-mode-btn.is-active{background:var(--primary); color:#fff; box-shadow:0 6px 16px rgba(0,0,0,.22);}
+.adv-mode-btn.is-active{background:var(--primary); color:#fff; box-shadow:0 4px 12px rgba(0,0,0,.22);}
 .adv-title{margin:0; font-size:15px}
 .adv-title-right{display:flex; align-items:baseline; gap:10px; justify-content:space-between}
 .adv-title-right .spacer{flex:1 1 auto}
-.adv-panels{display:grid; grid-template-columns:minmax(0, 2fr) minmax(0, 1fr); gap:16px}
+.adv-panels{display:grid; grid-template-columns: 2fr 1fr; gap:12px}
 .adv-panels.is-ie-mode{grid-template-columns:1fr;}
 .adv-panels.is-ie-mode .adv-right{grid-column:1;}
 .adv-left, .adv-right{min-width:0}
-@media (max-width:1080px){
-  .adv-panels{ grid-template-columns:repeat(2, minmax(0, 1fr)); }
-}
-@media (max-width:900px){
-  .adv-panels{ grid-template-columns:minmax(0, 1fr); }
-  .adv-panels .adv-right{ grid-column:1; }
-}
-.adv-actions{display:grid; grid-template-columns:minmax(0, 1.2fr) minmax(0, 0.9fr); gap:16px; margin-top:12px}
+.adv-actions{display:grid; grid-template-columns: 2fr 1fr; gap:12px; margin-top:10px}
 .adv-actions .row{margin-top:0}
 /* Make Quiz Editor action buttons equal width within their rows */
 .adv-actions .row:first-child .btn{ flex:1 1 0; min-width:0 }
@@ -595,122 +565,15 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .adv-group.files .btn:hover{ filter: brightness(1.04) }
 
 /* Reconsidered Quiz Editor layout: tidy two-column clusters with graceful wrap */
-.adv-row{ display:flex; flex-wrap:wrap; gap:12px; align-items:stretch; justify-content:space-between }
+.adv-row{ display:flex; flex-wrap:wrap; gap:var(--space-3); align-items:stretch; justify-content:space-between }
 .adv-group{ display:flex; gap:8px; align-items:stretch; flex-wrap:wrap }
 .adv-group.files{ flex: 3 1 420px }
 .adv-group.run{ flex: 1 1 260px; justify-content:flex-end }
 .adv-group .btn{ flex: 1 1 160px; min-width: 0 }
 .adv-group.run #startBtn{ flex: 1.2 1 200px }
-@media (max-width: 900px){
-  .adv-actions{ grid-template-columns:1fr; }
-  .adv-group.run{ justify-content:flex-start; }
-}
 @media (max-width: 600px){
   .adv-group.files, .adv-group.run{ flex-basis: 100%; justify-content:stretch }
   .adv-group .btn{ flex-basis: 100% }
-}
-
-.editor-pane{
-  display:flex;
-  flex-direction:column;
-  gap:10px;
-  min-height:var(--adv-box-min);
-  background:var(--panel-2);
-  border:1px solid var(--field-border);
-  border-radius:8px;
-  padding:16px;
-  box-shadow:0 2px 10px rgba(0,0,0,.25);
-}
-body[data-theme="light"] .editor-pane{
-  background:var(--panel);
-  border-color:var(--border);
-  box-shadow:0 2px 10px rgba(0,0,0,.2);
-}
-.editor-pane__header{
-  display:flex;
-  flex-wrap:wrap;
-  gap:6px 12px;
-  align-items:center;
-  justify-content:space-between;
-  margin-bottom:10px;
-}
-.editor-pane__title{
-  font-size:.78rem;
-  font-weight:700;
-  letter-spacing:.14em;
-  text-transform:uppercase;
-  color:var(--muted);
-}
-.editor-pane__hint{
-  font-size:.8rem;
-  color:var(--muted);
-  opacity:.85;
-  margin-left:auto;
-  text-align:right;
-}
-.editor-pane textarea{
-  width:100%;
-  min-height:var(--adv-box-min);
-  border-radius:8px;
-  padding:12px 14px;
-  border:1px solid var(--field-border);
-  background:var(--field);
-  color:var(--text);
-  line-height:1.45;
-  resize:vertical;
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
-  transition:border-color .15s ease, box-shadow .2s ease, background .2s ease;
-}
-body[data-theme="light"] .editor-pane textarea{
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
-}
-.editor-pane textarea:hover{ border-color:var(--border); }
-.editor-pane textarea:focus{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
-  box-shadow:var(--focus-shadow);
-}
-.editor-pane .mirror-box{
-  border:1px solid var(--field-border);
-  background:var(--panel-2);
-  border-radius:8px;
-  padding:12px;
-  display:flex;
-  min-height:var(--adv-box-min);
-  box-shadow:none;
-  font-family:var(--mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
-  font-size:.9rem;
-  transition:border-color .15s ease, background .2s ease;
-}
-body[data-theme="light"] .editor-pane .mirror-box{
-  background:var(--panel);
-  border-color:var(--border);
-}
-.editor-pane .mirror-box[data-empty="true"]::after{
-  content:"Waiting for generated quiz…";
-  font-size:.82rem;
-  color:var(--muted);
-  letter-spacing:.02em;
-  margin:auto;
-  padding:0 12px;
-  text-align:center;
-  opacity:.7;
-  display:none;
-}
-.editor-pane .mirror-box[data-empty="true"][data-on="true"]::after{ display:block; }
-.editor-pane .mirror-box textarea{
-  border:0;
-  background:transparent;
-  padding:0;
-  width:100%;
-  line-height:1.45;
-  resize:vertical;
-  color:var(--text);
-}
-.editor-pane .mirror-box textarea:focus{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
-  box-shadow:var(--focus-shadow);
 }
 
 /* Copy/Export row as a clean two-up grid */
@@ -718,28 +581,48 @@ body[data-theme="light"] .editor-pane .mirror-box{
 @media (max-width: 600px){ .advanced-actions{ grid-template-columns: 1fr } }
 
 /* Keep boxes visually in sync */
-:root{ --adv-box-min: 280px; }
-.editor-pane textarea,
-.editor-pane .mirror-box{ min-height: var(--adv-box-min); }
-.editor-pane .mirror-box[data-on="false"]{ display:none }
+:root{ --adv-box-min: 260px; }
+.adv-panels .editor,
+.adv-panels .mirror-box{ min-height: var(--adv-box-min); }
+.adv-panels .editor{ width:100%; height:auto; line-height:1.45 }
+.mirror-box{ border:1px solid var(--field-border); background:var(--panel-2); border-radius:var(--radius-card); padding:0; display:flex; }
+body[data-theme="light"] .mirror-box{ background:var(--panel); }
+.mirror-box textarea{ border:0; background:transparent; padding:10px 12px; width:100%; height:auto; line-height:1.45; resize:vertical }
+.mirror-box[data-on="false"]{ display:none }
+/* Mirror empty placeholder */
+.mirror-box[data-empty="true"]{ position:relative }
+.mirror-box[data-empty="true"]::before{
+  content:'Generated quiz lines will appear here…';
+  position:absolute; inset:10px 12px auto 12px; color:var(--muted); opacity:.8; pointer-events:none; font-size:.9em;
+}
+
+/* Keep focus ring visible when focusing textarea inside mirror */
+.mirror-box textarea:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow) }
 
 /* Mirror toggle size harmony */
 .opt-switch.small{ padding:6px 8px }
 .opt-switch.small input{ transform:scale(0.95) }
 
+/* Stack below ~768px */
 @media (max-width: 768px){
   .adv-head{ grid-template-columns: 1fr; align-items:center }
   .adv-title-right{ justify-content:flex-start; gap:12px }
+  .adv-panels{ grid-template-columns: 1fr }
+  .adv-actions{ grid-template-columns: 1fr }
+  .adv-panels .editor,
+  .adv-panels .mirror-box{ min-height: 0 }
 }
 @media (max-width: 600px){
-  .editor-pane{ padding:16px; }
-  .editor-pane__header{ align-items:flex-start; }
   .adv-mode-toggle{ width:100%; justify-content:space-between }
   .adv-mode-btn{ flex:1 1 0; padding:8px 12px; text-align:center }
   .mirror-toggle{ width:100%; justify-content:space-between; padding:8px 12px }
   .mirror-toggle-label{ font-size:.85rem; }
   .mirror-toggle input{ transform:scale(1.05); }
 }
+@media (max-width:560px){
+  .gen-toolbar{grid-template-columns:1fr;}
+}
+
 .grid{display:grid; grid-template-columns:1fr 1fr; gap:16px}
  @media (max-width:880px){.grid{grid-template-columns:1fr}}
 
@@ -752,8 +635,8 @@ body[data-theme="light"] .editor-pane .mirror-box{
   border:1px solid var(--field-border);
   background:var(--field);
   color:var(--text);
-  border-radius:8px;
-  padding:12px 12px;
+  border-radius:var(--radius-control);
+  padding:12px;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
   transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
 }
@@ -770,10 +653,10 @@ body[data-theme="light"] .editor-pane .mirror-box{
 
 /* Buttons */
 .row{display:flex; align-items:center}
-.gap{gap:12px}
+.gap{gap:var(--space-3)}
 .btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); padding:12px 16px; border-radius:10px; cursor:pointer; min-width:112px;
+  color:var(--text); padding:10px 14px; border-radius:var(--radius-control); cursor:pointer; min-width:112px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease, background-color .15s ease;
   line-height:1.2;
   display:inline-flex; align-items:center; justify-content:center;
@@ -843,7 +726,7 @@ body[data-theme="light"] .btn-solid{ color:#f7f9ff; }
 
 /* Quiz Editor legacy helpers */
 .advanced{margin-top:12px}
-.advanced-body{padding:10px; background:var(--panel-2); border-radius:12px}
+.advanced-body{padding:var(--space-3); background:var(--panel-2); border-radius:var(--radius-card)}
 details.advanced > summary{display:none}
 
 /* Visibility */
@@ -1135,7 +1018,7 @@ body.is-quiz .hero{ /* transform: scale(.96); opacity:.9; */ }
   .icon-btn{padding:8px 10px; font-size:16px}
   /* Global button scale down */
   .btn{padding:10px 12px; font-size:14px; min-width:0}
-  .gen-toolbar{padding:22px 12px 12px; gap:26px 8px}
+  .gen-toolbar{padding:12px; gap:8px}
   .number-wrap{ border-radius:14px; }
   .stepper-group{ width:28px; }
   .stepper{ font-size:.6rem; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -367,11 +367,11 @@ body[data-theme="light"] .number-wrap{ background:var(--panel); }
   flex-direction:column;
   justify-content:center;
   gap:var(--space-2);
-  padding:var(--space-3) 12px var(--space-2);
+  padding:calc(var(--space-2) + 2px) 12px var(--space-2);
   border-radius:var(--radius-control);
   background:var(--panel-2);
   border:1px solid var(--field-border);
-  min-height:calc(var(--toolbar-control-height) + var(--space-2));
+  min-height:var(--toolbar-control-height);
   transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .difficulty-stack{ background:var(--panel); }
@@ -403,13 +403,13 @@ body[data-theme="light"] .difficulty-label{
   box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .difficulty-slider{
-  --thumb-size:clamp(16px, 3.4vw, 18px);
+  --thumb-size:clamp(14px, 2.8vw, 16px);
   --track-height:2px;
   --dot-size:4px;
   position:relative;
   width:100%;
   max-width:100%;
-  padding:8px 0;
+  padding:4px 0;
 }
 .difficulty-slider input[type="range"]{
   width:100%;

--- a/public/styles.css
+++ b/public/styles.css
@@ -24,6 +24,9 @@
   --radius-lg:20px;
   --toolbar-glow:rgba(122, 162, 255, .16);
   --editor-glow:rgba(122, 162, 255, .12);
+  --space-1:6px;
+  --space-2:10px;
+  --space-3:12px;
 }
 
 body[data-theme="light"]{
@@ -113,7 +116,7 @@ body[data-theme="dark"] .site-header .brand-link{
   border-radius:8px;
   padding:16px;
   margin-bottom:16px;
-  box-shadow:0 2px 6px rgba(0,0,0,.25);
+  box-shadow:0 2px 10px rgba(0,0,0,.25);
 }
 /* Keep quiz runner comfortably large on desktop */
 @media (min-width: 900px){
@@ -130,47 +133,37 @@ body[data-theme="dark"] .site-header .brand-link{
 .gen-toolbar{
   --toolbar-control-height:clamp(40px, 4vw, 44px);
   display:grid;
-  grid-template-columns:minmax(260px, 360px) minmax(200px, 220px) minmax(80px, 88px) minmax(0, 1fr);
+  grid-template-columns:1fr auto auto auto;
   align-items:center;
-  gap:12px;
-  background:linear-gradient(180deg, rgba(24,29,42,.96), rgba(18,22,32,.92));
+  gap:var(--space-3);
+  background:linear-gradient(180deg, rgba(21,25,37,.98), rgba(21,25,37,.94));
   border:1px solid var(--field-border);
   border-radius:8px;
-  padding:18px 20px;
-  margin:0 auto 12px;
-  max-width:900px;
-  box-shadow:0 2px 6px rgba(0,0,0,.25);
+  padding:var(--space-3) calc(var(--space-3) + 4px);
+  margin-inline:auto;
+  margin-block-end:16px;
+  max-width:960px;
+  box-shadow:0 2px 10px rgba(0,0,0,.25);
   grid-auto-rows:minmax(var(--toolbar-control-height), auto);
 }
 body[data-theme="light"] .gen-toolbar{
-  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(244,248,254,.94));
   border-color:var(--border);
-  box-shadow:0 2px 6px rgba(0,0,0,.25);
+  box-shadow:0 2px 10px rgba(0,0,0,.2);
 }
 .gen-toolbar > *{ min-width:0; }
-.gen-toolbar .toolbar-field{
-  height:var(--toolbar-control-height);
-}
 .gen-toolbar .topic-field{
-  min-width:200px;
+  min-width:260px;
   max-width:360px;
   width:100%;
-  justify-self:stretch;
 }
 .gen-toolbar .difficulty-field{
-  display:flex;
-  align-items:center;
-  min-width:200px;
-  max-width:220px;
-  height:var(--toolbar-control-height);
+  min-width:220px;
   width:100%;
-  justify-self:stretch;
 }
 .gen-toolbar .length-field{
-  min-width:72px;
-  max-width:88px;
+  min-width:96px;
   width:100%;
-  justify-self:stretch;
 }
 .gen-toolbar .toolbar-actions{
   display:flex;
@@ -181,8 +174,8 @@ body[data-theme="light"] .gen-toolbar{
   justify-self:end;
 }
 .gen-toolbar .toolbar-actions .btn{
-  height:var(--toolbar-control-height);
-  padding:6px 12px;
+  min-height:var(--toolbar-control-height);
+  padding:6px 10px;
   font-size:.9rem;
   border-radius:8px;
   min-width:120px;
@@ -201,37 +194,31 @@ body[data-theme="light"] .gen-toolbar{
   outline-offset:2px;
   box-shadow:var(--focus-shadow);
 }
-@media (min-width:1024px){
+@media (max-width:1024px){
   .gen-toolbar{
-    grid-template-columns:minmax(260px, 360px) minmax(200px, 220px) minmax(80px, 88px) minmax(0, 1fr);
-  }
-}
-@media (max-width:1023px){
-  .gen-toolbar{
-    grid-template-columns:minmax(0, 1fr) auto;
-    grid-auto-rows:min-content;
-    align-items:start;
-    gap:10px;
+    grid-template-columns:1fr auto auto;
+    align-items:end;
+    row-gap:var(--space-2);
   }
   .gen-toolbar .toolbar-actions{
+    grid-column:1 / -1;
     justify-self:end;
   }
 }
 @media (max-width:720px){
   .gen-toolbar{
-    grid-template-columns:1fr auto;
-    gap:8px;
-    padding:16px;
+    grid-template-columns:1fr;
+    align-items:stretch;
+    padding:var(--space-3);
+  }
+  .gen-toolbar .toolbar-actions{
+    justify-content:flex-end;
+    width:100%;
   }
 }
 @media (max-width:480px){
-  .gen-toolbar{
-    grid-template-columns:1fr;
-    grid-auto-rows:minmax(var(--toolbar-control-height), auto);
-  }
   .gen-toolbar .toolbar-actions{
     justify-content:stretch;
-    justify-self:stretch;
   }
   .gen-toolbar .toolbar-actions .btn{
     flex:1 1 100%;
@@ -244,7 +231,9 @@ body[data-theme="light"] .gen-toolbar{
   align-items:center;
   flex:1 1 auto;
   min-width:160px;
-  height:var(--toolbar-control-height, 44px);
+  min-height:calc(var(--toolbar-control-height, 44px) + var(--space-2));
+  padding:var(--space-3) 10px var(--space-2);
+  width:100%;
 }
 .toolbar-field > .toolbar-input{
   flex:1 1 auto;
@@ -253,11 +242,12 @@ body[data-theme="light"] .gen-toolbar{
 .toolbar-field.narrow{ flex:1 1 150px; min-width:120px; }
 .toolbar-label{
   position:absolute;
-  top:-12px;
+  top:-10px;
   left:10px;
-  right:10px;
-  padding:0;
-  background:transparent;
+  padding:2px 8px;
+  border-radius:8px;
+  background:var(--panel);
+  border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
   color:var(--muted);
@@ -267,19 +257,25 @@ body[data-theme="light"] .gen-toolbar{
   text-align:left;
   z-index:1;
   pointer-events:none;
+  box-shadow:0 1px 2px rgba(0,0,0,.28);
+}
+body[data-theme="light"] .toolbar-label{
+  background:var(--panel-2);
+  border-color:var(--border);
+  box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .toolbar-input{
   border:1px solid var(--field-border);
-  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
+  background:var(--panel-2);
   color:var(--text);
   border-radius:8px;
-  height:100%;
-  padding:0 12px;
+  min-height:var(--toolbar-control-height);
+  padding:10px 12px;
   font-size:.9rem;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .toolbar-input{
-  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
+  background:var(--panel);
 }
 .toolbar-input:hover{
   background:var(--field-hover);
@@ -301,16 +297,14 @@ body[data-theme="light"] .toolbar-input{
   display:flex;
   align-items:stretch;
   border:1px solid var(--field-border);
-  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
+  background:var(--panel-2);
   border-radius:8px;
   overflow:hidden;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
-  height:100%;
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+  min-height:var(--toolbar-control-height);
 }
 body[data-theme="light"] .number-wrap{
-  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(235,240,250,.94));
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+  background:var(--panel);
 }
 .number-wrap:hover{
   background:var(--field-hover);
@@ -326,8 +320,8 @@ body[data-theme="light"] .number-wrap{
   width:100%;
   border:0;
   background:transparent;
-  padding:0 12px;
-  height:100%;
+  padding:10px 12px;
+  min-height:var(--toolbar-control-height);
   color:var(--text);
   box-shadow:none;
 }
@@ -352,7 +346,7 @@ body[data-theme="light"] .number-wrap{
   width:26px;
   border-left:1px solid var(--field-border);
   background:var(--panel-2);
-  height:100%;
+  min-height:var(--toolbar-control-height);
 }
 .stepper{
   flex:1 1 50%;
@@ -394,18 +388,17 @@ body[data-theme="light"] .number-wrap{
   align-items:center;
   justify-content:center;
   flex:1 1 auto;
-  min-width:180px;
-  height:var(--toolbar-control-height, 44px);
-  padding:0 16px;
+  min-width:220px;
+  min-height:calc(var(--toolbar-control-height, 44px) + var(--space-2));
+  padding:var(--space-3) 10px var(--space-2);
   border-radius:8px;
-  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
+  background:var(--panel-2);
   border:1px solid var(--field-border);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
-  transition:border-color .15s ease, box-shadow .2s ease;
+  transition:border-color .15s ease, box-shadow .2s ease, background .15s ease;
+  width:100%;
 }
 body[data-theme="light"] .difficulty-stack{
-  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+  background:var(--panel);
 }
 .difficulty-stack:hover{ border-color:var(--border); }
 .difficulty-stack:focus-within{
@@ -415,11 +408,12 @@ body[data-theme="light"] .difficulty-stack{
 .difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
-  top:-12px;
+  top:-10px;
   left:10px;
-  right:10px;
-  padding:0;
-  background:transparent;
+  padding:2px 8px;
+  border-radius:8px;
+  background:var(--panel);
+  border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
   color:var(--muted);
@@ -429,15 +423,21 @@ body[data-theme="light"] .difficulty-stack{
   text-align:left;
   z-index:1;
   pointer-events:none;
+  box-shadow:0 1px 2px rgba(0,0,0,.28);
+}
+body[data-theme="light"] .difficulty-label{
+  background:var(--panel-2);
+  border-color:var(--border);
+  box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .difficulty-slider{
   --thumb-size:clamp(16px, 3.6vw, 18px);
-  --track-height:8px;
+  --track-height:2px;
   --dot-size:4px;
   position:relative;
   width:100%;
   max-width:100%;
-  padding:calc(var(--thumb-size) / 2 + 2px) 0;
+  padding:8px 0;
 }
 .difficulty-slider input[type="range"]{
   width:100%;
@@ -470,29 +470,31 @@ body[data-theme="light"] .difficulty-stack{
   border-radius:50%;
   background:var(--primary);
   border:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.4);
+  box-shadow:0 1px 2px rgba(0,0,0,.35);
   margin-top:calc((var(--track-height) - var(--thumb-size)) / 2);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.25); }
+body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.2); }
 .difficulty-slider input[type="range"]::-moz-range-thumb{
   width:var(--thumb-size);
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
   border:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.4);
+  box-shadow:0 1px 2px rgba(0,0,0,.35);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.25); }
-.difficulty-slider input[type="range"]:focus-visible{
-  outline:2px solid var(--ring);
-  outline-offset:4px;
+body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.2); }
+.difficulty-slider input[type="range"]:focus{ outline:none; }
+.difficulty-slider input[type="range"]:focus-visible::-webkit-slider-thumb{
+  box-shadow:0 0 0 2px rgba(122,162,255,.45), 0 1px 2px rgba(0,0,0,.35);
+}
+.difficulty-slider input[type="range"]:focus-visible::-moz-range-thumb{
+  box-shadow:0 0 0 2px rgba(122,162,255,.45), 0 1px 2px rgba(0,0,0,.35);
 }
 .difficulty-slider input[type="range"]:active::-webkit-slider-thumb,
 .difficulty-slider input[type="range"]:active::-moz-range-thumb{
-  transform:scale(1.05);
-  box-shadow:0 2px 4px rgba(0,0,0,.35);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.18), 0 1px 2px rgba(0,0,0,.35);
 }
 .difficulty-track{
   position:absolute;
@@ -502,27 +504,20 @@ body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thum
   height:var(--track-height);
   transform:translateY(-50%);
   pointer-events:none;
-}
-.difficulty-track::before{
-  content:"";
-  position:absolute;
-  inset:0;
-  background:linear-gradient(90deg, rgba(122,162,255,.18), rgba(122,162,255,.06) 80%);
-  border:1px solid rgba(122,162,255,.24);
+  background:rgba(122,162,255,.22);
   border-radius:999px;
-  box-shadow:inset 0 0 0 1px rgba(0,0,0,.15);
-  z-index:0;
-  transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
+  transition:background .2s ease;
 }
-body[data-theme="light"] .difficulty-track::before{
-  background:linear-gradient(90deg, rgba(36,92,255,.16), rgba(36,92,255,.06) 82%);
-  border-color:rgba(36,92,255,.22);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.45);
+body[data-theme="light"] .difficulty-track{
+  background:rgba(36,92,255,.18);
 }
-.difficulty-slider:hover .difficulty-track::before,
-.difficulty-stack:focus-within .difficulty-track::before{
-  border-color:var(--ring);
-  box-shadow:inset 0 0 0 1px rgba(126,163,255,.35);
+.difficulty-slider:hover .difficulty-track,
+.difficulty-stack:focus-within .difficulty-track{
+  background:rgba(122,162,255,.35);
+}
+body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track,
+body[data-theme="light"] .difficulty-slider:hover .difficulty-track{
+  background:rgba(36,92,255,.32);
 }
 .difficulty-dot{
   position:absolute;
@@ -537,16 +532,13 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .difficulty-track .difficulty-dot:nth-child(1){ left:25%; }
 .difficulty-track .difficulty-dot:nth-child(2){ left:50%; }
 .difficulty-track .difficulty-dot:nth-child(3){ left:75%; }
-.difficulty-slider:hover .difficulty-track::before{
-  background:var(--field-hover);
-}
 .difficulty-slider input[type="range"]::-moz-focus-outer{ border:0; }
 
 /* Options panel (drop-down) */
 .options-panel{
-  margin:8px auto 0; max-width:900px;
+  margin:8px auto 0; max-width:960px;
   border:1px solid var(--field-border); background:var(--panel-2); border-radius:8px;
-  padding:10px; box-shadow:0 2px 6px rgba(0,0,0,.25);
+  padding:10px; box-shadow:0 2px 10px rgba(0,0,0,.25);
   transition:opacity .2s ease, transform .2s ease;
 }
 .options-panel[hidden]{display:none}
@@ -627,12 +619,12 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
   border:1px solid var(--field-border);
   border-radius:8px;
   padding:16px;
-  box-shadow:0 2px 6px rgba(0,0,0,.25);
+  box-shadow:0 2px 10px rgba(0,0,0,.25);
 }
 body[data-theme="light"] .editor-pane{
   background:var(--panel);
   border-color:var(--border);
-  box-shadow:0 2px 6px rgba(0,0,0,.2);
+  box-shadow:0 2px 10px rgba(0,0,0,.2);
 }
 .editor-pane__header{
   display:flex;
@@ -680,18 +672,19 @@ body[data-theme="light"] .editor-pane textarea{
 }
 .editor-pane .mirror-box{
   border:1px solid var(--field-border);
-  background:var(--panel);
+  background:var(--panel-2);
   border-radius:8px;
   padding:12px;
   display:flex;
   min-height:var(--adv-box-min);
-  box-shadow:0 2px 6px rgba(0,0,0,.25);
-  transition:border-color .15s ease, box-shadow .2s ease;
+  box-shadow:none;
+  font-family:var(--mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  font-size:.9rem;
+  transition:border-color .15s ease, background .2s ease;
 }
 body[data-theme="light"] .editor-pane .mirror-box{
-  background:var(--panel-2);
+  background:var(--panel);
   border-color:var(--border);
-  box-shadow:0 2px 6px rgba(0,0,0,.2);
 }
 .editor-pane .mirror-box[data-empty="true"]::after{
   content:"Waiting for generated quiz…";

--- a/public/styles.css
+++ b/public/styles.css
@@ -21,13 +21,13 @@
   --field-border:#33405a;
   --field-hover:#121a27;
   --focus-shadow:0 0 0 3px rgba(126, 163, 255, .35);
-  --radius-lg:20px;
-  --radius-card:8px;
+  --radius-card:12px;
   --radius-control:8px;
-  --shadow-card:0 2px 8px rgba(0,0,0,.25);
+  --shadow-card:0 6px 18px rgba(0,0,0,.22);
+  --shadow-float:0 10px 28px rgba(0,0,0,.24);
   --space-1:6px;
   --space-2:10px;
-  --space-3:12px;
+  --space-3:16px;
 }
 
 body[data-theme="light"]{
@@ -50,7 +50,7 @@ body[data-theme="light"]{
   --field-border:#cfd8ea;
   --field-hover:#e8edf6;
   --focus-shadow:0 0 0 3px rgba(110, 163, 255, .35);
-  --shadow-card:0 2px 8px rgba(15,23,42,.18);
+  --shadow-card:0 6px 18px rgba(15,23,42,.16);
 }
 
 *{box-sizing:border-box}
@@ -84,8 +84,15 @@ body[data-theme="light"] .brand-logo{
 }
 .header-actions{display:flex; gap:10px}
 .icon-btn{
-  appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); border-radius:var(--radius-control); padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
+  appearance:none;
+  border:1px solid var(--border);
+  background:var(--panel-2);
+  color:var(--text);
+  border-radius:var(--radius-control);
+  padding:10px 16px;
+  cursor:pointer;
+  line-height:1;
+  font-size:20px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease;
 }
 .icon-btn:hover{filter:brightness(1.06)}
@@ -131,146 +138,117 @@ body[data-theme="dark"] .site-header .brand-link{
 
 /* Generate toolbar */
 .gen-toolbar{
-  --toolbar-control-height:clamp(40px, 3.5vw, 44px);
+  --toolbar-height:clamp(40px, 4vw, 44px);
   display:grid;
-  grid-template-columns:minmax(0,1fr) minmax(220px,1fr) minmax(96px,auto) auto auto;
-  align-items:center;
-  gap:var(--space-3);
-  background:linear-gradient(180deg, rgba(21,25,37,.98), rgba(21,25,37,.92));
+  grid-template-columns:minmax(220px,1.8fr) minmax(200px,1.2fr) minmax(96px,auto) auto auto;
+  grid-template-areas:"topic difficulty length generate options";
+  align-items:stretch;
+  gap:var(--space-2);
+  background:linear-gradient(180deg, rgba(21,25,37,.96), rgba(21,25,37,.9));
   border:1px solid var(--field-border);
   border-radius:var(--radius-card);
-  padding:var(--space-3);
+  padding:var(--space-2) var(--space-3);
   margin:0 auto 16px;
   max-width:960px;
   box-shadow:var(--shadow-card);
-  grid-auto-rows:minmax(var(--toolbar-control-height), auto);
+  grid-auto-rows:minmax(var(--toolbar-height), auto);
 }
 body[data-theme="light"] .gen-toolbar{
-  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(244,248,254,.94));
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(246,249,255,.94));
   border-color:var(--border);
-  box-shadow:0 2px 8px rgba(15,23,42,.16);
+  box-shadow:0 8px 20px rgba(15,23,42,.12);
 }
 .gen-toolbar > *{ min-width:0; }
-.gen-toolbar > .toolbar-field{ min-width:260px; }
-.gen-toolbar .toolbar-pair{
-  grid-column:2 / 4;
-  display:grid;
-  grid-template-columns:minmax(220px,1fr) minmax(96px,auto);
-  gap:var(--space-3);
-  align-items:stretch;
-  min-width:0;
-}
-.gen-toolbar .difficulty-stack{ min-width:220px; }
-.gen-toolbar .number-field{ min-width:96px; }
-.gen-toolbar #generateBtn,
-.gen-toolbar #optionsBtn{
-  min-height:var(--toolbar-control-height);
-  padding:6px 12px;
-  font-size:.9rem;
-  border-radius:var(--radius-control);
+.gen-toolbar .toolbar-pair{ display:contents; }
+.gen-toolbar > .toolbar-field:first-of-type{ grid-area:topic; }
+.gen-toolbar .difficulty-stack{ grid-area:difficulty; min-width:200px; align-self:stretch; }
+.gen-toolbar .number-field{ grid-area:length; min-width:96px; align-self:stretch; }
+.gen-toolbar #generateBtn{
+  grid-area:generate;
   justify-self:end;
   align-self:stretch;
-  min-width:128px;
+  min-width:132px;
+  min-height:var(--toolbar-height, 44px);
+  padding:0 16px;
+  border-radius:var(--radius-control);
+  font-size:.95rem;
 }
-.gen-toolbar #generateBtn{ grid-column:4; }
-.gen-toolbar #optionsBtn{ grid-column:5; }
+.gen-toolbar #optionsBtn{
+  grid-area:options;
+  justify-self:end;
+  align-self:stretch;
+  min-width:120px;
+  min-height:var(--toolbar-height, 44px);
+  padding:0 16px;
+  border-radius:var(--radius-control);
+  font-size:.95rem;
+}
 
 @media (max-width:1024px){
   .gen-toolbar{
-    grid-template-columns:minmax(0,1fr) minmax(220px,1fr) auto;
-    grid-auto-rows:minmax(var(--toolbar-control-height), auto);
-    row-gap:var(--space-2);
+    grid-template-columns:minmax(220px,1fr) minmax(200px,1fr) minmax(96px,auto) auto;
+    grid-template-areas:
+      "topic difficulty length generate"
+      "topic difficulty length options";
   }
-  .gen-toolbar .toolbar-pair{ grid-column:2; }
-  .gen-toolbar #generateBtn{ grid-column:3; }
-  .gen-toolbar #optionsBtn{ grid-column:3; grid-row:2; }
 }
 
 @media (max-width:720px){
   .gen-toolbar{
     grid-template-columns:1fr;
-    padding:var(--space-3);
+    grid-template-areas:
+      "topic"
+      "difficulty"
+      "length"
+      "generate"
+      "options";
+    padding:var(--space-2) 14px;
   }
-  .gen-toolbar > .toolbar-field{ min-width:0; }
-  .gen-toolbar .toolbar-pair{
-    grid-column:1;
-    grid-template-columns:1fr;
-  }
+  .gen-toolbar > .toolbar-field:first-of-type,
   .gen-toolbar .difficulty-stack,
-  .gen-toolbar .number-field{ min-width:0; }
+  .gen-toolbar .number-field,
   .gen-toolbar #generateBtn,
   .gen-toolbar #optionsBtn{
-    grid-column:1;
-    grid-row:auto;
-    justify-self:stretch;
     min-width:0;
+    width:100%;
+  }
+  .gen-toolbar #generateBtn,
+  .gen-toolbar #optionsBtn{
+    justify-self:stretch;
   }
 }
 
 @media (max-width:480px){
-  .gen-toolbar{
-    gap:var(--space-2);
-  }
-  .gen-toolbar #generateBtn,
-  .gen-toolbar #optionsBtn{
-    width:100%;
-  }
+  .gen-toolbar{ gap:var(--space-1); }
 }
 .toolbar-field{
-  position:relative;
   display:flex;
   flex-direction:column;
-  gap:var(--space-2);
-  align-items:stretch;
-  flex:1 1 auto;
-  padding-top:var(--space-3);
+  gap:var(--space-1);
+  align-items:flex-start;
+  min-width:0;
 }
-.toolbar-field.narrow{ flex:0 0 auto; }
+.toolbar-field.narrow{ min-width:0; }
 .toolbar-label{
-  position:absolute;
-  top:-10px;
-  left:12px;
-  padding:2px 8px;
-  border-radius:var(--radius-control);
-  background:var(--panel);
-  border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
   letter-spacing:.05em;
   text-transform:uppercase;
-  line-height:1;
   color:var(--muted);
-  text-align:left;
-  pointer-events:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.28);
-}
-body[data-theme="light"] .toolbar-label{
-  background:var(--panel-2);
-  border-color:var(--border);
-  box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .toolbar-input{
   border:1px solid var(--field-border);
   background:var(--panel-2);
   color:var(--text);
   border-radius:var(--radius-control);
-  min-height:var(--toolbar-control-height);
-  padding:10px 12px;
-  font-size:.9rem;
-  transition:background .18s ease, border-color .18s ease, box-shadow .2s ease;
+  min-height:var(--toolbar-height, 44px);
+  padding:0 12px;
+  font-size:.95rem;
+  transition:background .15s ease, border-color .15s ease, box-shadow .18s ease;
 }
-body[data-theme="light"] .toolbar-input{
-  background:var(--panel);
-}
-.toolbar-input:hover{
-  background:var(--field-hover);
-  border-color:var(--border);
-}
-.toolbar-input:focus{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
-  box-shadow:var(--focus-shadow);
-}
+body[data-theme="light"] .toolbar-input{ background:var(--panel); }
+.toolbar-input:hover{ background:var(--field-hover); border-color:var(--border); }
+.toolbar-input:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow); }
 .gen-toolbar #countInput{ text-align:center; }
 .number-wrap{
   position:relative;
@@ -281,14 +259,11 @@ body[data-theme="light"] .toolbar-input{
   background:var(--panel-2);
   border-radius:var(--radius-control);
   overflow:hidden;
-  transition:background .18s ease, border-color .18s ease, box-shadow .2s ease;
-  min-height:var(--toolbar-control-height);
+  transition:background .15s ease, border-color .15s ease, box-shadow .18s ease;
+  min-height:var(--toolbar-height, 44px);
 }
 body[data-theme="light"] .number-wrap{ background:var(--panel); }
-.number-wrap:hover{
-  background:var(--field-hover);
-  border-color:var(--border);
-}
+.number-wrap:hover{ background:var(--field-hover); border-color:var(--border); }
 .number-wrap:focus-within{
   outline:2px solid var(--ring);
   outline-offset:2px;
@@ -300,9 +275,8 @@ body[data-theme="light"] .number-wrap{ background:var(--panel); }
   border:0;
   background:transparent;
   padding:0 12px;
-  min-height:var(--toolbar-control-height);
+  min-height:var(--toolbar-height, 44px);
   color:var(--text);
-  font-size:.9rem;
   box-shadow:none;
 }
 .number-wrap .toolbar-input:hover,
@@ -332,9 +306,7 @@ body[data-theme="light"] .number-wrap{ background:var(--panel); }
   border:0;
   background:transparent;
   color:var(--muted);
-  font-size:.6rem;
-  font-weight:600;
-  letter-spacing:.08em;
+  font-size:.55rem;
   line-height:1;
   display:flex;
   align-items:center;
@@ -366,50 +338,35 @@ body[data-theme="light"] .number-wrap{ background:var(--panel); }
   display:flex;
   flex-direction:column;
   justify-content:center;
-  gap:var(--space-2);
-  padding:calc(var(--space-2) + 2px) 12px var(--space-2);
+  gap:var(--space-1);
+  padding:var(--space-1) 12px;
   border-radius:var(--radius-control);
-  background:var(--panel-2);
   border:1px solid var(--field-border);
-  min-height:var(--toolbar-control-height);
-  transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
+  background:var(--panel-2);
+  min-height:var(--toolbar-height, 44px);
+  transition:border-color .18s ease, background .18s ease, box-shadow .18s ease;
 }
 body[data-theme="light"] .difficulty-stack{ background:var(--panel); }
 .difficulty-stack:hover{ border-color:var(--border); }
 .difficulty-stack:focus-within{
   border-color:var(--ring);
   box-shadow:var(--focus-shadow);
+  background:var(--panel);
 }
 .difficulty-label{
-  position:absolute;
-  top:-10px;
-  left:12px;
-  padding:2px 8px;
-  border-radius:var(--radius-control);
-  background:var(--panel);
-  border:1px solid var(--field-border);
   font-size:.75rem;
   font-weight:600;
   letter-spacing:.05em;
   text-transform:uppercase;
-  line-height:1;
   color:var(--muted);
-  pointer-events:none;
-  box-shadow:0 1px 2px rgba(0,0,0,.28);
-}
-body[data-theme="light"] .difficulty-label{
-  background:var(--panel-2);
-  border-color:var(--border);
-  box-shadow:0 1px 2px rgba(0,0,0,.12);
 }
 .difficulty-slider{
-  --thumb-size:clamp(14px, 2.8vw, 16px);
-  --track-height:2px;
+  --thumb-size:clamp(16px, 2.8vw, 18px);
+  --track-height:4px;
   --dot-size:4px;
   position:relative;
   width:100%;
-  max-width:100%;
-  padding:4px 0;
+  padding:6px 0;
 }
 .difficulty-slider input[type="range"]{
   width:100%;
@@ -444,10 +401,7 @@ body[data-theme="light"] .difficulty-label{
   border:none;
   box-shadow:0 1px 2px rgba(0,0,0,.4);
   margin-top:calc((var(--track-height) - var(--thumb-size)) / 2);
-  transition:transform .15s ease, box-shadow .2s ease;
-}
-body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{
-  box-shadow:0 1px 2px rgba(0,0,0,.25);
+  transition:transform .15s ease, box-shadow .15s ease;
 }
 .difficulty-slider input[type="range"]::-moz-range-thumb{
   width:var(--thumb-size);
@@ -456,21 +410,18 @@ body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-
   background:var(--primary);
   border:none;
   box-shadow:0 1px 2px rgba(0,0,0,.4);
-  transition:transform .15s ease, box-shadow .2s ease;
+  transition:transform .15s ease, box-shadow .15s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{
-  box-shadow:0 1px 2px rgba(0,0,0,.25);
-}
-.difficulty-slider input[type="range"]:focus{ outline:none; }
+.difficulty-slider input[type="range"]:focus-visible{ outline:none; }
 .difficulty-slider input[type="range"]:focus-visible::-webkit-slider-thumb{
-  box-shadow:0 0 0 2px color-mix(in oklab, var(--brand) 60%, transparent), 0 1px 2px rgba(0,0,0,.4);
+  box-shadow:0 0 0 3px rgba(122,162,255,.35), 0 1px 2px rgba(0,0,0,.4);
 }
 .difficulty-slider input[type="range"]:focus-visible::-moz-range-thumb{
-  box-shadow:0 0 0 2px color-mix(in oklab, var(--brand) 60%, transparent), 0 1px 2px rgba(0,0,0,.4);
+  box-shadow:0 0 0 3px rgba(122,162,255,.35), 0 1px 2px rgba(0,0,0,.4);
 }
 .difficulty-slider input[type="range"]:active::-webkit-slider-thumb,
 .difficulty-slider input[type="range"]:active::-moz-range-thumb{
-  box-shadow:inset 0 0 0 1px rgba(0,0,0,.18), 0 1px 2px rgba(0,0,0,.4);
+  transform:scale(1.05);
 }
 .difficulty-track{
   position:absolute;
@@ -480,31 +431,35 @@ body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thum
   height:var(--track-height);
   transform:translateY(-50%);
   pointer-events:none;
-  background:rgba(122,162,255,.28);
+}
+.difficulty-track::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:rgba(122,162,255,.2);
   border-radius:999px;
-  transition:background .2s ease;
+  z-index:0;
+  opacity:.7;
+  transition:opacity .2s ease, background .2s ease;
 }
-body[data-theme="light"] .difficulty-track{ background:rgba(36,92,255,.2); }
-.difficulty-slider:hover .difficulty-track,
-.difficulty-stack:focus-within .difficulty-track{
-  background:rgba(122,162,255,.4);
-}
-body[data-theme="light"] .difficulty-slider:hover .difficulty-track,
-body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track{
-  background:rgba(36,92,255,.32);
-}
+body[data-theme="light"] .difficulty-track::before{ background:rgba(76,115,196,.2); }
 .difficulty-dot{
   position:absolute;
   top:50%;
   width:var(--dot-size);
   height:var(--dot-size);
   border-radius:50%;
-  background:var(--field-border);
+  background:var(--border);
   transform:translate(-50%, -50%);
 }
 .difficulty-track .difficulty-dot:nth-child(1){ left:25%; }
 .difficulty-track .difficulty-dot:nth-child(2){ left:50%; }
 .difficulty-track .difficulty-dot:nth-child(3){ left:75%; }
+.difficulty-slider:hover .difficulty-track::before{ opacity:.9; }
+.difficulty-slider:focus-within .difficulty-track::before{
+  background:rgba(122,162,255,.32);
+  opacity:1;
+}
 .difficulty-slider input[type="range"]::-moz-focus-outer{ border:0; }
 
 /* Options panel (drop-down) */
@@ -514,26 +469,28 @@ body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track{
   border:1px solid var(--field-border);
   background:var(--panel-2);
   border-radius:var(--radius-card);
-  padding:var(--space-3);
-  box-shadow:var(--shadow-card);
+  padding:14px;
+  box-shadow:var(--shadow-float);
   transition:opacity .2s ease, transform .2s ease;
 }
+body[data-theme="light"] .options-panel{ background:var(--panel); }
 .options-panel[hidden]{display:none}
 .options-regular .lbl{color:var(--muted); font-size:14px}
-.opt-switch{display:inline-flex; align-items:center; gap:var(--space-1); padding:6px 10px; border:1px solid var(--field-border); background:var(--panel); border-radius:var(--radius-control)}
+.opt-switch{display:inline-flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid var(--field-border); background:var(--panel-2); border-radius:var(--radius-control);}
+body[data-theme="light"] .opt-switch{ background:var(--panel); }
 .opt-switch input{transform:scale(1)}
 .mirror-toggle{gap:12px; padding:6px 12px; background:var(--panel-2); border-color:var(--field-border); justify-content:space-between; min-width:0; border-radius:var(--radius-control);}
 .mirror-toggle-label{font-size:.8rem; font-weight:600; color:var(--muted); text-transform:none;}
 .mirror-toggle input{transform:scale(0.95); margin-left:4px;}
 .inline.small-field input{min-width:96px}
 .muted.small{color:var(--muted); font-size:.9em}
-.divider{height:1px; background:var(--border); margin:var(--space-3) calc(var(--space-3) * -1)}
+.divider{height:1px; background:var(--border); margin:var(--space-2) calc(var(--space-2) * -1)}
 .advanced-disclosure{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; cursor:pointer; border-radius:var(--radius-control)}
 .advanced-disclosure:focus-visible{outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow)}
 .advanced-disclosure:hover{background:var(--field-hover)}
 .advanced-disclosure .caret{display:inline-block; transition:transform .18s ease}
 .advanced-disclosure[aria-expanded="true"] .caret{transform:rotate(-180deg)}
-.advanced-body{padding:var(--space-3); background:var(--panel-2); border-radius:var(--radius-card); animation:fadeSlide .22s ease}
+.advanced-body{padding:var(--space-2); background:var(--panel-2); border-radius:var(--radius-card); animation:fadeSlide .22s ease}
 @keyframes fadeSlide{from{opacity:0; transform:translateY(-4px)} to{opacity:1; transform:none}}
 .row.wrap{flex-wrap:wrap}
 
@@ -565,7 +522,7 @@ body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track{
 .adv-group.files .btn:hover{ filter: brightness(1.04) }
 
 /* Reconsidered Quiz Editor layout: tidy two-column clusters with graceful wrap */
-.adv-row{ display:flex; flex-wrap:wrap; gap:var(--space-3); align-items:stretch; justify-content:space-between }
+.adv-row{ display:flex; flex-wrap:wrap; gap:12px; align-items:stretch; justify-content:space-between }
 .adv-group{ display:flex; gap:8px; align-items:stretch; flex-wrap:wrap }
 .adv-group.files{ flex: 3 1 420px }
 .adv-group.run{ flex: 1 1 260px; justify-content:flex-end }
@@ -585,9 +542,16 @@ body[data-theme="light"] .difficulty-stack:focus-within .difficulty-track{
 .adv-panels .editor,
 .adv-panels .mirror-box{ min-height: var(--adv-box-min); }
 .adv-panels .editor{ width:100%; height:auto; line-height:1.45 }
-.mirror-box{ border:1px solid var(--field-border); background:var(--panel-2); border-radius:var(--radius-card); padding:0; display:flex; }
+.mirror-box{
+  border:1px solid var(--field-border);
+  background:var(--panel-2);
+  border-radius:var(--radius-card);
+  padding:0;
+  display:flex;
+  box-shadow:0 4px 14px rgba(0,0,0,.2);
+}
 body[data-theme="light"] .mirror-box{ background:var(--panel); }
-.mirror-box textarea{ border:0; background:transparent; padding:10px 12px; width:100%; height:auto; line-height:1.45; resize:vertical }
+.mirror-box textarea{ border:0; background:transparent; padding:12px; width:100%; height:auto; line-height:1.45; resize:vertical }
 .mirror-box[data-on="false"]{ display:none }
 /* Mirror empty placeholder */
 .mirror-box[data-empty="true"]{ position:relative }
@@ -613,6 +577,9 @@ body[data-theme="light"] .mirror-box{ background:var(--panel); }
   .adv-panels .mirror-box{ min-height: 0 }
 }
 @media (max-width: 600px){
+  .gen-toolbar > .toolbar-pair{ flex:1 1 100%; min-width:0; }
+  .gen-toolbar .toolbar-pair{ gap:10px; }
+  .gen-toolbar .toolbar-pair .toolbar-field.narrow{ flex:1 1 150px; min-width:130px; }
   .adv-mode-toggle{ width:100%; justify-content:space-between }
   .adv-mode-btn{ flex:1 1 0; padding:8px 12px; text-align:center }
   .mirror-toggle{ width:100%; justify-content:space-between; padding:8px 12px }
@@ -635,8 +602,8 @@ body[data-theme="light"] .mirror-box{ background:var(--panel); }
   border:1px solid var(--field-border);
   background:var(--field);
   color:var(--text);
-  border-radius:var(--radius-control);
-  padding:12px;
+  border-radius:12px;
+  padding:12px 12px;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
   transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
 }
@@ -653,10 +620,10 @@ body[data-theme="light"] .mirror-box{ background:var(--panel); }
 
 /* Buttons */
 .row{display:flex; align-items:center}
-.gap{gap:var(--space-3)}
+.gap{gap:12px}
 .btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); padding:10px 14px; border-radius:var(--radius-control); cursor:pointer; min-width:112px;
+  color:var(--text); padding:12px 16px; border-radius:14px; cursor:pointer; min-width:112px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease, background-color .15s ease;
   line-height:1.2;
   display:inline-flex; align-items:center; justify-content:center;
@@ -726,7 +693,6 @@ body[data-theme="light"] .btn-solid{ color:#f7f9ff; }
 
 /* Quiz Editor legacy helpers */
 .advanced{margin-top:12px}
-.advanced-body{padding:var(--space-3); background:var(--panel-2); border-radius:var(--radius-card)}
 details.advanced > summary{display:none}
 
 /* Visibility */

--- a/public/styles.css
+++ b/public/styles.css
@@ -82,7 +82,7 @@ body[data-theme="light"] .brand-logo{
 .header-actions{display:flex; gap:10px}
 .icon-btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); border-radius:10px; padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
+  color:var(--text); border-radius:8px; padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease;
 }
 .icon-btn:hover{filter:brightness(1.06)}
@@ -110,10 +110,10 @@ body[data-theme="dark"] .site-header .brand-link{
 .card{
   background:var(--panel);
   border:1px solid var(--border);
-  border-radius:10px;
+  border-radius:8px;
   padding:16px;
   margin-bottom:16px;
-  box-shadow:0 8px 18px rgba(5,8,17,.22);
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
 }
 /* Keep quiz runner comfortably large on desktop */
 @media (min-width: 900px){
@@ -135,17 +135,17 @@ body[data-theme="dark"] .site-header .brand-link{
   gap:12px;
   background:linear-gradient(180deg, rgba(24,29,42,.96), rgba(18,22,32,.92));
   border:1px solid var(--field-border);
-  border-radius:10px;
+  border-radius:8px;
   padding:18px 20px;
   margin:0 auto 12px;
   max-width:900px;
-  box-shadow:0 10px 24px rgba(5, 8, 17, .26);
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
   grid-auto-rows:minmax(var(--toolbar-control-height), auto);
 }
 body[data-theme="light"] .gen-toolbar{
   background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
   border-color:var(--border);
-  box-shadow:0 10px 20px rgba(15,23,42,.12);
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
 }
 .gen-toolbar > *{ min-width:0; }
 .gen-toolbar .toolbar-field{
@@ -253,35 +253,29 @@ body[data-theme="light"] .gen-toolbar{
 .toolbar-field.narrow{ flex:1 1 150px; min-width:120px; }
 .toolbar-label{
   position:absolute;
-  bottom:calc(100% - 4px);
-  left:14px;
-  padding:2px 8px;
-  background:rgba(14, 20, 30, .82);
-  border-radius:8px;
-  font-size:.7rem;
+  top:-12px;
+  left:10px;
+  right:10px;
+  padding:0;
+  background:transparent;
+  font-size:.75rem;
   font-weight:600;
   color:var(--muted);
-  letter-spacing:.12em;
+  letter-spacing:.05em;
   line-height:1;
   text-transform:uppercase;
+  text-align:left;
   z-index:1;
-  transform:translateY(-2px);
-  border:1px solid rgba(255,255,255,.05);
-  box-shadow:0 6px 16px rgba(4, 6, 12, .32);
-}
-body[data-theme="light"] .toolbar-label{
-  background:rgba(255,255,255,.92);
-  border-color:rgba(15,23,42,.08);
-  box-shadow:0 8px 18px rgba(15,23,42,.08);
+  pointer-events:none;
 }
 .toolbar-input{
   border:1px solid var(--field-border);
   background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
   color:var(--text);
-  border-radius:9px;
+  border-radius:8px;
   height:100%;
   padding:0 12px;
-  font-size:.95rem;
+  font-size:.9rem;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .toolbar-input{
@@ -299,8 +293,6 @@ body[data-theme="light"] .toolbar-input{
 .toolbar-field:focus-within .toolbar-label,
 .difficulty-stack:focus-within .difficulty-label{
   color:var(--text);
-  border-color:var(--ring);
-  box-shadow:0 0 0 3px rgba(126, 163, 255, .28);
 }
 .gen-toolbar #countInput{ text-align:center; }
 .number-wrap{
@@ -310,7 +302,7 @@ body[data-theme="light"] .toolbar-input{
   align-items:stretch;
   border:1px solid var(--field-border);
   background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
-  border-radius:9px;
+  border-radius:8px;
   overflow:hidden;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
   height:100%;
@@ -379,10 +371,10 @@ body[data-theme="light"] .number-wrap{
 }
 .stepper:first-child{
   border-bottom:1px solid var(--field-border);
-  border-top-right-radius:9px;
+  border-top-right-radius:8px;
 }
 .stepper:last-child{
-  border-bottom-right-radius:9px;
+  border-bottom-right-radius:8px;
 }
 .stepper:hover{
   background:var(--field-hover);
@@ -405,7 +397,7 @@ body[data-theme="light"] .number-wrap{
   min-width:180px;
   height:var(--toolbar-control-height, 44px);
   padding:0 16px;
-  border-radius:9px;
+  border-radius:8px;
   background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
   border:1px solid var(--field-border);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
@@ -423,30 +415,24 @@ body[data-theme="light"] .difficulty-stack{
 .difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
-  bottom:calc(100% - 4px);
-  left:18px;
-  padding:2px 8px;
-  background:rgba(14, 20, 30, .82);
-  border-radius:8px;
-  font-size:.7rem;
+  top:-12px;
+  left:10px;
+  right:10px;
+  padding:0;
+  background:transparent;
+  font-size:.75rem;
   font-weight:600;
   color:var(--muted);
-  letter-spacing:.12em;
+  letter-spacing:.05em;
   line-height:1;
   text-transform:uppercase;
+  text-align:left;
   z-index:1;
-  transform:translateY(-2px);
-  border:1px solid rgba(255,255,255,.05);
-  box-shadow:0 6px 16px rgba(4, 6, 12, .32);
-}
-body[data-theme="light"] .difficulty-label{
-  background:rgba(255,255,255,.92);
-  border-color:rgba(15,23,42,.08);
-  box-shadow:0 8px 18px rgba(15,23,42,.08);
+  pointer-events:none;
 }
 .difficulty-slider{
-  --thumb-size:clamp(22px, 4vw, 28px);
-  --track-height:10px;
+  --thumb-size:clamp(16px, 3.6vw, 18px);
+  --track-height:8px;
   --dot-size:4px;
   position:relative;
   width:100%;
@@ -483,36 +469,30 @@ body[data-theme="light"] .difficulty-label{
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
-  border:3px solid rgba(11, 16, 24, .72);
-  box-shadow:0 10px 24px rgba(122,162,255,.36);
+  border:none;
+  box-shadow:0 1px 2px rgba(0,0,0,.4);
   margin-top:calc((var(--track-height) - var(--thumb-size)) / 2);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{
-  border-color:rgba(255,255,255,.9);
-  box-shadow:0 10px 22px rgba(36,92,255,.28);
-}
+body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.25); }
 .difficulty-slider input[type="range"]::-moz-range-thumb{
   width:var(--thumb-size);
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
-  border:3px solid rgba(11, 16, 24, .72);
-  box-shadow:0 10px 24px rgba(122,162,255,.36);
+  border:none;
+  box-shadow:0 1px 2px rgba(0,0,0,.4);
   transition:transform .15s ease, box-shadow .2s ease;
 }
-body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{
-  border-color:rgba(255,255,255,.9);
-  box-shadow:0 10px 22px rgba(36,92,255,.28);
-}
+body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{ box-shadow:0 1px 2px rgba(0,0,0,.25); }
 .difficulty-slider input[type="range"]:focus-visible{
   outline:2px solid var(--ring);
   outline-offset:4px;
 }
 .difficulty-slider input[type="range"]:active::-webkit-slider-thumb,
 .difficulty-slider input[type="range"]:active::-moz-range-thumb{
-  transform:scale(1.06);
-  box-shadow:0 12px 26px rgba(122,162,255,.42);
+  transform:scale(1.05);
+  box-shadow:0 2px 4px rgba(0,0,0,.35);
 }
 .difficulty-track{
   position:absolute;
@@ -527,22 +507,22 @@ body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thum
   content:"";
   position:absolute;
   inset:0;
-  background:linear-gradient(90deg, rgba(122,162,255,.22), rgba(122,162,255,.05) 80%);
-  border:1px solid rgba(122,162,255,.28);
+  background:linear-gradient(90deg, rgba(122,162,255,.18), rgba(122,162,255,.06) 80%);
+  border:1px solid rgba(122,162,255,.24);
   border-radius:999px;
-  box-shadow:inset 0 0 0 1px rgba(0,0,0,.2);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.15);
   z-index:0;
   transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .difficulty-track::before{
-  background:linear-gradient(90deg, rgba(36,92,255,.2), rgba(36,92,255,.08) 82%);
-  border-color:rgba(36,92,255,.24);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.55);
+  background:linear-gradient(90deg, rgba(36,92,255,.16), rgba(36,92,255,.06) 82%);
+  border-color:rgba(36,92,255,.22);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.45);
 }
 .difficulty-slider:hover .difficulty-track::before,
 .difficulty-stack:focus-within .difficulty-track::before{
   border-color:var(--ring);
-  box-shadow:inset 0 0 0 1px rgba(126,163,255,.45);
+  box-shadow:inset 0 0 0 1px rgba(126,163,255,.35);
 }
 .difficulty-dot{
   position:absolute;
@@ -565,8 +545,8 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 /* Options panel (drop-down) */
 .options-panel{
   margin:8px auto 0; max-width:900px;
-  border:1px solid var(--field-border); background:var(--panel-2); border-radius:12px;
-  padding:10px; box-shadow:0 10px 24px rgba(0,0,0,.25);
+  border:1px solid var(--field-border); background:var(--panel-2); border-radius:8px;
+  padding:10px; box-shadow:0 2px 6px rgba(0,0,0,.25);
   transition:opacity .2s ease, transform .2s ease;
 }
 .options-panel[hidden]{display:none}
@@ -579,12 +559,12 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .inline.small-field input{min-width:96px}
 .muted.small{color:var(--muted); font-size:.9em}
 .divider{height:1px; background:var(--border); margin:10px -10px}
-.advanced-disclosure{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; cursor:pointer; border-radius:10px}
+.advanced-disclosure{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; cursor:pointer; border-radius:8px}
 .advanced-disclosure:focus-visible{outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow)}
 .advanced-disclosure:hover{background:var(--field-hover)}
 .advanced-disclosure .caret{display:inline-block; transition:transform .18s ease}
 .advanced-disclosure[aria-expanded="true"] .caret{transform:rotate(-180deg)}
-.advanced-body{padding:10px; background:var(--panel-2); border-radius:12px; animation:fadeSlide .22s ease}
+.advanced-body{padding:10px; background:var(--panel-2); border-radius:8px; animation:fadeSlide .22s ease}
 @keyframes fadeSlide{from{opacity:0; transform:translateY(-4px)} to{opacity:1; transform:none}}
 .row.wrap{flex-wrap:wrap}
 
@@ -645,14 +625,14 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
   min-height:var(--adv-box-min);
   background:var(--panel-2);
   border:1px solid var(--field-border);
-  border-radius:10px;
+  border-radius:8px;
   padding:16px;
-  box-shadow:0 8px 20px rgba(5,8,17,.22);
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
 }
 body[data-theme="light"] .editor-pane{
   background:var(--panel);
   border-color:var(--border);
-  box-shadow:0 6px 16px rgba(15,23,42,.12);
+  box-shadow:0 2px 6px rgba(0,0,0,.2);
 }
 .editor-pane__header{
   display:flex;
@@ -705,13 +685,13 @@ body[data-theme="light"] .editor-pane textarea{
   padding:12px;
   display:flex;
   min-height:var(--adv-box-min);
-  box-shadow:0 4px 12px rgba(5,8,17,.18);
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
   transition:border-color .15s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .editor-pane .mirror-box{
   background:var(--panel-2);
   border-color:var(--border);
-  box-shadow:0 4px 12px rgba(15,23,42,.12);
+  box-shadow:0 2px 6px rgba(0,0,0,.2);
 }
 .editor-pane .mirror-box[data-empty="true"]::after{
   content:"Waiting for generated quiz…";

--- a/public/styles.css
+++ b/public/styles.css
@@ -120,52 +120,76 @@ body[data-theme="dark"] .site-header .brand-link{
 
 /* Generate toolbar */
 .gen-toolbar{
-  display:flex;
-  align-items:center;
-  gap:26px 10px;
-  flex-wrap:wrap;
+  --toolbar-gap:clamp(16px, 3.6vw, 24px);
+  --toolbar-input-height:48px;
   background:var(--panel);
   border:1px solid var(--field-border);
   border-radius:var(--radius-lg, 20px);
-  padding:22px 16px 16px;
-  margin:0 auto 12px;
-  max-width:900px;
+  padding:clamp(20px, 4vw, 26px);
+  margin:0 auto 16px;
+  max-width:960px;
   box-shadow:var(--shadow-xs);
 }
-.gen-toolbar > *{ flex-shrink:0; }
-.gen-toolbar > .toolbar-pair{ flex:1 1 280px; flex-shrink:1; display:flex; gap:12px; align-items:center; min-width:260px; }
-.gen-toolbar .toolbar-field{ flex:1 1 200px; min-width:150px; }
-.gen-toolbar .toolbar-field.narrow{ flex:0 0 80px; min-width:80px; }
-.gen-toolbar .toolbar-pair .toolbar-field.narrow{ flex:1 1 160px; min-width:140px; }
-.gen-toolbar .toolbar-pair .number-wrap{ width:100%; }
-.gen-toolbar .toolbar-pair .difficulty-stack,
-.gen-toolbar .difficulty-stack{ flex:1 1 auto; }
-.gen-toolbar #generateBtn,
-.gen-toolbar #optionsBtn{
-  flex:0 0 auto;
-  min-width:110px;
-  height:44px;
-  display:inline-flex;
+.gen-toolbar__layout{
+  display:grid;
+  gap:var(--toolbar-gap);
+  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+  align-items:end;
+}
+.gen-toolbar__layout > *{ min-width:0; }
+@media (min-width:900px){
+  .gen-toolbar__layout > .topic-field{ grid-column:span 2; }
+}
+.toolbar-duo{
+  display:grid;
+  gap:12px;
+  grid-template-columns:minmax(220px, 1fr) minmax(120px, .75fr);
+  align-items:end;
+  min-width:0;
+}
+@media (max-width:880px){
+  .toolbar-duo{ grid-template-columns:1fr; }
+}
+.toolbar-actions{
+  display:flex;
+  gap:12px;
+  justify-content:flex-end;
   align-items:center;
-  justify-content:center;
+  min-width:0;
+}
+.toolbar-actions .btn{
+  flex:0 0 auto;
+  min-width:132px;
+  height:var(--toolbar-input-height);
+}
+@media (max-width:880px){
+  .toolbar-actions{
+    flex-direction:column;
+    align-items:stretch;
+    justify-content:stretch;
+  }
+  .toolbar-actions .btn{
+    min-width:0;
+    width:100%;
+  }
 }
 .toolbar-field{
   position:relative;
   display:flex;
   align-items:center;
-  flex:1 1 auto;
-  min-width:150px;
-  height:44px;
+  min-width:0;
+  width:100%;
+  height:var(--toolbar-input-height, 48px);
 }
 .toolbar-field > .toolbar-input{
   flex:1 1 auto;
   width:100%;
+  height:100%;
 }
-.toolbar-field.narrow{ flex:0 0 80px; min-width:80px; }
 .toolbar-label{
   position:absolute;
   bottom:100%;
-  left:16px;
+  left:18px;
   padding:0;
   background:transparent;
   border-radius:0;
@@ -182,8 +206,10 @@ body[data-theme="dark"] .site-header .brand-link{
   background:var(--field);
   color:var(--text);
   border-radius:12px;
-  height:44px;
-  padding:0 12px;
+  height:100%;
+  min-height:var(--toolbar-input-height, 48px);
+  padding:0 14px;
+  transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
 }
 .toolbar-input:hover{background:var(--field-hover); border-color:var(--border)}
 .toolbar-input:focus{outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow)}
@@ -276,16 +302,28 @@ body[data-theme="dark"] .site-header .brand-link{
   display:flex;
   align-items:center;
   justify-content:center;
-  flex:1 1 auto;
-  min-width:150px;
-  height:44px;
-  padding:0 8px;
+  min-width:160px;
+  height:var(--toolbar-input-height, 48px);
+  padding:0 14px;
+  border:1px solid var(--field-border);
+  background:var(--field);
+  border-radius:12px;
+  transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
+}
+.difficulty-stack:hover{
+  background:var(--field-hover);
+  border-color:var(--border);
+}
+.difficulty-stack:focus-within{
+  outline:2px solid var(--ring);
+  outline-offset:2px;
+  box-shadow:var(--focus-shadow);
 }
 .difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
   bottom:100%;
-  left:16px;
+  left:18px;
   padding:0;
   background:transparent;
   border-radius:0;
@@ -434,10 +472,16 @@ body[data-theme="dark"] .site-header .brand-link{
 .adv-title{margin:0; font-size:15px}
 .adv-title-right{display:flex; align-items:baseline; gap:10px; justify-content:space-between}
 .adv-title-right .spacer{flex:1 1 auto}
-.adv-panels{display:grid; grid-template-columns: 2fr 1fr; gap:12px}
-.adv-panels.is-ie-mode{grid-template-columns:1fr;}
-.adv-panels.is-ie-mode .adv-right{grid-column:1;}
-.adv-left, .adv-right{min-width:0}
+:root{ --adv-box-min: 260px; }
+.adv-panels{
+  display:grid;
+  gap:16px;
+  grid-template-columns:minmax(0, 1.2fr) minmax(0, .8fr);
+  align-items:stretch;
+}
+.adv-panels.is-ie-mode{ grid-template-columns:1fr; }
+.adv-panels.is-ie-mode .adv-right{ grid-column:auto; }
+.adv-left, .adv-right{ min-width:0 }
 .adv-actions{display:grid; grid-template-columns: 2fr 1fr; gap:12px; margin-top:10px}
 .adv-actions .row{margin-top:0}
 /* Make Quiz Editor action buttons equal width within their rows */
@@ -468,18 +512,58 @@ body[data-theme="dark"] .site-header .brand-link{
 @media (max-width: 600px){ .advanced-actions{ grid-template-columns: 1fr } }
 
 /* Keep boxes visually in sync */
-:root{ --adv-box-min: 260px; }
 .adv-panels .editor,
 .adv-panels .mirror-box{ min-height: var(--adv-box-min); }
 .adv-panels .editor{ width:100%; height:auto; line-height:1.45 }
 .mirror-box{ border:1px solid var(--field-border); background:var(--field); border-radius:12px; padding:0; display:flex; }
-.mirror-box textarea{ border:0; background:transparent; padding:12px; width:100%; height:auto; line-height:1.45; resize:vertical }
+.mirror-box textarea{ border:0; background:transparent; padding:16px; width:100%; height:auto; line-height:1.5; resize:vertical }
 .mirror-box[data-on="false"]{ display:none }
 /* Mirror empty placeholder */
 .mirror-box[data-empty="true"]{ position:relative }
 .mirror-box[data-empty="true"]::before{
   content:'Generated quiz lines will appear here…';
-  position:absolute; inset:10px 12px auto 12px; color:var(--muted); opacity:.8; pointer-events:none; font-size:.9em;
+  position:absolute; inset:16px 18px auto 18px; color:var(--muted); opacity:.8; pointer-events:none; font-size:.9em;
+}
+
+.ie-pane{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:16px;
+  background:var(--panel-2);
+  border:1px solid var(--field-border);
+  border-radius:16px;
+  box-shadow:var(--shadow-xs);
+  min-height:100%;
+}
+body[data-theme="light"] .ie-pane{ background:var(--panel); }
+.ie-pane__header{
+  display:flex;
+  align-items:baseline;
+  justify-content:space-between;
+  gap:12px;
+}
+.ie-pane__title{
+  font-size:.95rem;
+  font-weight:600;
+  letter-spacing:.015em;
+}
+.ie-pane__hint{
+  color:var(--muted);
+  font-size:.75rem;
+  line-height:1.3;
+}
+.ie-pane textarea{
+  flex:1 1 auto;
+  min-height:var(--adv-box-min);
+  padding:16px;
+  border-radius:12px;
+}
+.ie-pane[data-pane="mirror"] .mirror-box{
+  flex:1 1 auto;
+}
+.ie-pane[data-pane="mirror"] .mirror-box textarea{
+  height:100%;
 }
 
 /* Keep focus ring visible when focusing textarea inside mirror */
@@ -499,17 +583,11 @@ body[data-theme="dark"] .site-header .brand-link{
   .adv-panels .mirror-box{ min-height: 0 }
 }
 @media (max-width: 600px){
-  .gen-toolbar > .toolbar-pair{ flex:1 1 100%; min-width:0; }
-  .gen-toolbar .toolbar-pair{ gap:10px; }
-  .gen-toolbar .toolbar-pair .toolbar-field.narrow{ flex:1 1 150px; min-width:130px; }
   .adv-mode-toggle{ width:100%; justify-content:space-between }
   .adv-mode-btn{ flex:1 1 0; padding:8px 12px; text-align:center }
   .mirror-toggle{ width:100%; justify-content:space-between; padding:8px 12px }
   .mirror-toggle-label{ font-size:.85rem; }
   .mirror-toggle input{ transform:scale(1.05); }
-}
-@media (max-width:560px){
-  .gen-toolbar{grid-template-columns:1fr;}
 }
 
 .grid{display:grid; grid-template-columns:1fr 1fr; gap:16px}

--- a/public/styles.css
+++ b/public/styles.css
@@ -248,7 +248,11 @@ body[data-theme="light"] .gen-toolbar{
 }
 body[data-theme="light"] .toolbar-input{ background:var(--panel); }
 .toolbar-input:-webkit-autofill,
-.number-wrap .toolbar-input:-webkit-autofill{
+.toolbar-input:-webkit-autofill:focus,
+.toolbar-input:-webkit-autofill:hover,
+.number-wrap .toolbar-input:-webkit-autofill,
+.number-wrap .toolbar-input:-webkit-autofill:focus,
+.number-wrap .toolbar-input:-webkit-autofill:hover{
   -webkit-text-fill-color:var(--text);
   -webkit-box-shadow:0 0 0 1000px var(--panel-2) inset;
   box-shadow:0 0 0 1000px var(--panel-2) inset;
@@ -260,7 +264,11 @@ body[data-theme="light"] .number-wrap .toolbar-input:-webkit-autofill{
   box-shadow:0 0 0 1000px var(--panel) inset;
 }
 .toolbar-input:-moz-autofill,
-.number-wrap .toolbar-input:-moz-autofill{
+.toolbar-input:-moz-autofill:focus,
+.toolbar-input:-moz-autofill:hover,
+.number-wrap .toolbar-input:-moz-autofill,
+.number-wrap .toolbar-input:-moz-autofill:focus,
+.number-wrap .toolbar-input:-moz-autofill:hover{
   box-shadow:0 0 0 1000px var(--panel-2) inset;
   color:var(--text);
   -moz-text-fill-color:var(--text);
@@ -956,9 +964,15 @@ footer.container{
   padding-top:8px;
   padding-bottom:12px;
   /* Reserve space so floating buttons never cover the footer */
-  margin-bottom: calc(var(--fab-reserve, 112px) + env(safe-area-inset-bottom, 0px));
+  margin-bottom:0;
   /* Avoid FAB overlap on the right on narrow screens */
   padding-right: var(--fab-right-pad, 0px);
+}
+footer.container::after{
+  content:"";
+  display:block;
+  height: calc(var(--fab-reserve, 112px) + env(safe-area-inset-bottom, 0px));
+  background: var(--bg);
 }
 /* Helper text under toolbar */
 .subtle-help{ font-size:.9rem; opacity:.75; margin:.25rem 0 0 .25rem }

--- a/public/styles.css
+++ b/public/styles.css
@@ -247,35 +247,38 @@ body[data-theme="light"] .gen-toolbar{
   transition:background .15s ease, border-color .15s ease, box-shadow .18s ease;
 }
 body[data-theme="light"] .toolbar-input{ background:var(--panel); }
-.toolbar-input:-webkit-autofill,
-.toolbar-input:-webkit-autofill:focus,
-.toolbar-input:-webkit-autofill:hover,
-.number-wrap .toolbar-input:-webkit-autofill,
-.number-wrap .toolbar-input:-webkit-autofill:focus,
-.number-wrap .toolbar-input:-webkit-autofill:hover{
+.toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus),
+.number-wrap .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus){
   -webkit-text-fill-color:var(--text);
+  caret-color:var(--text);
+  background:var(--panel-2);
+  border:1px solid var(--field-border);
+  border-radius:var(--radius-control);
+  background-clip:padding-box;
   -webkit-box-shadow:0 0 0 1000px var(--panel-2) inset;
   box-shadow:0 0 0 1000px var(--panel-2) inset;
-  caret-color:var(--text);
 }
-body[data-theme="light"] .toolbar-input:-webkit-autofill,
-body[data-theme="light"] .number-wrap .toolbar-input:-webkit-autofill{
+body[data-theme="light"] .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus),
+body[data-theme="light"] .number-wrap .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus){
+  background:var(--panel);
   -webkit-box-shadow:0 0 0 1000px var(--panel) inset;
   box-shadow:0 0 0 1000px var(--panel) inset;
+  border-color:var(--border);
 }
-.toolbar-input:-moz-autofill,
-.toolbar-input:-moz-autofill:focus,
-.toolbar-input:-moz-autofill:hover,
-.number-wrap .toolbar-input:-moz-autofill,
-.number-wrap .toolbar-input:-moz-autofill:focus,
-.number-wrap .toolbar-input:-moz-autofill:hover{
+.toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus),
+.number-wrap .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus){
   box-shadow:0 0 0 1000px var(--panel-2) inset;
   color:var(--text);
   -moz-text-fill-color:var(--text);
+  background:var(--panel-2);
+  border:1px solid var(--field-border);
+  border-radius:var(--radius-control);
 }
-body[data-theme="light"] .toolbar-input:-moz-autofill,
-body[data-theme="light"] .number-wrap .toolbar-input:-moz-autofill{
+body[data-theme="light"] .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus),
+body[data-theme="light"] .number-wrap .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus){
   box-shadow:0 0 0 1000px var(--panel) inset;
+  background:var(--panel);
+  border-color:var(--border);
 }
 .toolbar-input:hover{ background:var(--field-hover); border-color:var(--border); }
 .toolbar-input:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow); }

--- a/public/styles.css
+++ b/public/styles.css
@@ -82,7 +82,7 @@ body[data-theme="light"] .brand-logo{
 .header-actions{display:flex; gap:10px}
 .icon-btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); border-radius:12px; padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
+  color:var(--text); border-radius:10px; padding:10px 16px; cursor:pointer; line-height:1; font-size:20px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease;
 }
 .icon-btn:hover{filter:brightness(1.06)}
@@ -108,8 +108,12 @@ body[data-theme="dark"] .site-header .brand-link{
 .container{max-width:1060px; margin:24px auto; padding:0 16px}
 #app{flex:1}
 .card{
-  background:var(--panel); border:1px solid var(--border); border-radius:16px;
-  padding:16px; margin-bottom:16px; box-shadow:0 6px 18px rgba(0,0,0,.2);
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:16px;
+  margin-bottom:16px;
+  box-shadow:0 8px 18px rgba(5,8,17,.22);
 }
 /* Keep quiz runner comfortably large on desktop */
 @media (min-width: 900px){
@@ -124,98 +128,115 @@ body[data-theme="dark"] .site-header .brand-link{
 
 /* Generate toolbar */
 .gen-toolbar{
-  --toolbar-control-height:clamp(48px, 5.8vw, 58px);
-  --toolbar-gap:clamp(16px, 2.8vw, 24px);
+  --toolbar-control-height:clamp(40px, 4vw, 44px);
   display:grid;
-  grid-template-columns:minmax(220px, 1.15fr) minmax(260px, 1fr) auto auto;
-  align-items:end;
-  gap:var(--toolbar-gap);
-  background:
-    radial-gradient(140% 180% at 100% 0%, var(--toolbar-glow), transparent 68%),
-    linear-gradient(180deg, rgba(255,255,255,.04), rgba(0,0,0,.18)),
-    var(--panel);
+  grid-template-columns:minmax(260px, 360px) minmax(200px, 220px) minmax(80px, 88px) minmax(0, 1fr);
+  align-items:center;
+  gap:12px;
+  background:linear-gradient(180deg, rgba(24,29,42,.96), rgba(18,22,32,.92));
   border:1px solid var(--field-border);
-  border-radius:clamp(18px, 3.4vw, 26px);
-  padding:26px clamp(16px, 4vw, 28px) 20px;
+  border-radius:10px;
+  padding:18px 20px;
   margin:0 auto 12px;
   max-width:900px;
-  box-shadow:0 18px 40px rgba(5, 8, 17, .45);
+  box-shadow:0 10px 24px rgba(5, 8, 17, .26);
+  grid-auto-rows:minmax(var(--toolbar-control-height), auto);
 }
 body[data-theme="light"] .gen-toolbar{
-  background:
-    radial-gradient(160% 200% at 100% 0%, var(--toolbar-glow), transparent 72%),
-    linear-gradient(180deg, rgba(255,255,255,.92), rgba(215,224,250,.72)),
-    var(--panel);
-  box-shadow:0 18px 32px rgba(15,23,42,.12);
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
+  border-color:var(--border);
+  box-shadow:0 10px 20px rgba(15,23,42,.12);
 }
 .gen-toolbar > *{ min-width:0; }
-.gen-toolbar > button.btn{
-  align-self:stretch;
-  justify-self:end;
-  min-width:140px;
+.gen-toolbar .toolbar-field{
   height:var(--toolbar-control-height);
-  padding:0 clamp(18px, 4vw, 26px);
-  font-weight:600;
-  letter-spacing:.01em;
-  transition:transform .12s ease, box-shadow .2s ease;
 }
-.gen-toolbar > button.btn:hover{
-  transform:translateY(-1px);
-  box-shadow:0 12px 28px rgba(8, 12, 20, .38);
+.gen-toolbar .topic-field{
+  min-width:200px;
+  max-width:360px;
+  width:100%;
+  justify-self:stretch;
 }
-body[data-theme="light"] .gen-toolbar > button.btn:hover{
-  box-shadow:0 12px 24px rgba(15,23,42,.15);
-}
-.gen-toolbar > button.btn:active{
-  transform:translateY(0);
-  box-shadow:none;
-}
-.gen-toolbar > button.btn:focus-visible{
-  transform:translateY(0);
-}
-.gen-toolbar .toolbar-pair{
+.gen-toolbar .difficulty-field{
   display:flex;
   align-items:center;
-  gap:16px;
-  min-width:260px;
-}
-.gen-toolbar .toolbar-field{ flex:1 1 220px; min-width:160px; height:var(--toolbar-control-height); }
-.gen-toolbar .toolbar-field.narrow{ flex:1 1 160px; min-width:140px; }
-.gen-toolbar .toolbar-pair .toolbar-field.narrow{ flex:1 1 160px; min-width:140px; }
-.gen-toolbar .toolbar-pair .number-wrap{ width:100%; }
-.gen-toolbar .toolbar-pair .difficulty-stack,
-.gen-toolbar .difficulty-stack{
-  flex:1 1 auto;
-  align-items:center;
+  min-width:200px;
+  max-width:220px;
   height:var(--toolbar-control-height);
-  padding:0 4px;
+  width:100%;
+  justify-self:stretch;
 }
-.gen-toolbar #generateBtn,
-.gen-toolbar #optionsBtn{ min-width:0; }
-@media (max-width:1024px){
+.gen-toolbar .length-field{
+  min-width:72px;
+  max-width:88px;
+  width:100%;
+  justify-self:stretch;
+}
+.gen-toolbar .toolbar-actions{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  flex-wrap:wrap;
+  gap:8px;
+  justify-self:end;
+}
+.gen-toolbar .toolbar-actions .btn{
+  height:var(--toolbar-control-height);
+  padding:6px 12px;
+  font-size:.9rem;
+  border-radius:8px;
+  min-width:120px;
+  transition:filter .15s ease, box-shadow .2s ease;
+}
+.gen-toolbar .toolbar-actions .btn:hover{
+  filter:brightness(1.06);
+  box-shadow:0 6px 16px rgba(5, 8, 17, .24);
+}
+.gen-toolbar .toolbar-actions .btn:active{
+  filter:brightness(.96);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
+}
+.gen-toolbar .toolbar-actions .btn:focus-visible{
+  outline:2px solid var(--ring);
+  outline-offset:2px;
+  box-shadow:var(--focus-shadow);
+}
+@media (min-width:1024px){
   .gen-toolbar{
-    grid-template-columns:repeat(2, minmax(0, 1fr));
+    grid-template-columns:minmax(260px, 360px) minmax(200px, 220px) minmax(80px, 88px) minmax(0, 1fr);
   }
-  .gen-toolbar > button.btn{
-    justify-self:stretch;
+}
+@media (max-width:1023px){
+  .gen-toolbar{
+    grid-template-columns:minmax(0, 1fr) auto;
+    grid-auto-rows:min-content;
+    align-items:start;
+    gap:10px;
+  }
+  .gen-toolbar .toolbar-actions{
+    justify-self:end;
   }
 }
 @media (max-width:720px){
   .gen-toolbar{
-    grid-template-columns:minmax(0, 1fr);
-    padding:24px clamp(14px, 6vw, 24px);
-  }
-  .gen-toolbar .toolbar-pair{
-    flex-direction:column;
-    align-items:stretch;
-    gap:14px;
-  }
-  .gen-toolbar > button.btn{
-    width:100%;
+    grid-template-columns:1fr auto;
+    gap:8px;
+    padding:16px;
   }
 }
 @media (max-width:480px){
-  .gen-toolbar{ --toolbar-control-height:clamp(48px, 14vw, 62px); }
+  .gen-toolbar{
+    grid-template-columns:1fr;
+    grid-auto-rows:minmax(var(--toolbar-control-height), auto);
+  }
+  .gen-toolbar .toolbar-actions{
+    justify-content:stretch;
+    justify-self:stretch;
+  }
+  .gen-toolbar .toolbar-actions .btn{
+    flex:1 1 100%;
+    min-width:0;
+  }
 }
 .toolbar-field{
   position:relative;
@@ -223,7 +244,7 @@ body[data-theme="light"] .gen-toolbar > button.btn:hover{
   align-items:center;
   flex:1 1 auto;
   min-width:160px;
-  height:var(--toolbar-control-height, 52px);
+  height:var(--toolbar-control-height, 44px);
 }
 .toolbar-field > .toolbar-input{
   flex:1 1 auto;
@@ -232,36 +253,39 @@ body[data-theme="light"] .gen-toolbar > button.btn:hover{
 .toolbar-field.narrow{ flex:1 1 150px; min-width:120px; }
 .toolbar-label{
   position:absolute;
-  bottom:calc(100% - 6px);
-  left:18px;
-  padding:4px 10px;
-  background:rgba(11, 16, 24, .78);
-  border-radius:999px;
-  font-size:.68rem;
-  font-weight:700;
+  bottom:calc(100% - 4px);
+  left:14px;
+  padding:2px 8px;
+  background:rgba(14, 20, 30, .82);
+  border-radius:8px;
+  font-size:.7rem;
+  font-weight:600;
   color:var(--muted);
-  letter-spacing:.14em;
+  letter-spacing:.12em;
   line-height:1;
   text-transform:uppercase;
   z-index:1;
-  transform:translateY(-4px);
-  border:1px solid rgba(255,255,255,.06);
-  box-shadow:0 10px 28px rgba(4, 6, 12, .4);
+  transform:translateY(-2px);
+  border:1px solid rgba(255,255,255,.05);
+  box-shadow:0 6px 16px rgba(4, 6, 12, .32);
 }
 body[data-theme="light"] .toolbar-label{
-  background:rgba(255,255,255,.9);
+  background:rgba(255,255,255,.92);
   border-color:rgba(15,23,42,.08);
-  box-shadow:0 12px 26px rgba(15,23,42,.08);
+  box-shadow:0 8px 18px rgba(15,23,42,.08);
 }
 .toolbar-input{
   border:1px solid var(--field-border);
-  background:linear-gradient(180deg, var(--panel-2), var(--field));
+  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
   color:var(--text);
-  border-radius:14px;
+  border-radius:9px;
   height:100%;
-  padding:0 16px;
-  font-size:1rem;
+  padding:0 12px;
+  font-size:.95rem;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
+}
+body[data-theme="light"] .toolbar-input{
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
 }
 .toolbar-input:hover{
   background:var(--field-hover);
@@ -285,15 +309,16 @@ body[data-theme="light"] .toolbar-label{
   display:flex;
   align-items:stretch;
   border:1px solid var(--field-border);
-  background:linear-gradient(180deg, var(--panel-2), var(--field));
-  border-radius:14px;
+  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
+  border-radius:9px;
   overflow:hidden;
   transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
   height:100%;
   box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
 }
 body[data-theme="light"] .number-wrap{
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.04);
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(235,240,250,.94));
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
 }
 .number-wrap:hover{
   background:var(--field-hover);
@@ -309,7 +334,7 @@ body[data-theme="light"] .number-wrap{
   width:100%;
   border:0;
   background:transparent;
-  padding:0 16px;
+  padding:0 12px;
   height:100%;
   color:var(--text);
   box-shadow:none;
@@ -332,7 +357,7 @@ body[data-theme="light"] .number-wrap{
   flex:0 0 auto;
   display:flex;
   flex-direction:column;
-  width:28px;
+  width:26px;
   border-left:1px solid var(--field-border);
   background:var(--panel-2);
   height:100%;
@@ -342,8 +367,8 @@ body[data-theme="light"] .number-wrap{
   border:0;
   background:transparent;
   color:var(--muted);
-  font-size:.6rem;
-  font-weight:700;
+  font-size:.58rem;
+  font-weight:600;
   line-height:1;
   display:flex;
   align-items:center;
@@ -354,10 +379,10 @@ body[data-theme="light"] .number-wrap{
 }
 .stepper:first-child{
   border-bottom:1px solid var(--field-border);
-  border-top-right-radius:14px;
+  border-top-right-radius:9px;
 }
 .stepper:last-child{
-  border-bottom-right-radius:14px;
+  border-bottom-right-radius:9px;
 }
 .stepper:hover{
   background:var(--field-hover);
@@ -378,16 +403,17 @@ body[data-theme="light"] .number-wrap{
   justify-content:center;
   flex:1 1 auto;
   min-width:180px;
-  height:var(--toolbar-control-height, 52px);
-  padding:0 20px;
-  border-radius:14px;
-  background:linear-gradient(180deg, var(--panel-2), var(--field));
+  height:var(--toolbar-control-height, 44px);
+  padding:0 16px;
+  border-radius:9px;
+  background:linear-gradient(180deg, rgba(25,31,44,.96), rgba(18,24,36,.92));
   border:1px solid var(--field-border);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
   transition:border-color .15s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .difficulty-stack{
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.04);
+  background:linear-gradient(180deg, rgba(255,255,255,.98), rgba(233,238,250,.94));
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
 }
 .difficulty-stack:hover{ border-color:var(--border); }
 .difficulty-stack:focus-within{
@@ -397,26 +423,26 @@ body[data-theme="light"] .difficulty-stack{
 .difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
-  bottom:calc(100% - 6px);
-  left:22px;
-  padding:4px 10px;
-  background:rgba(11, 16, 24, .78);
-  border-radius:999px;
-  font-size:.68rem;
-  font-weight:700;
+  bottom:calc(100% - 4px);
+  left:18px;
+  padding:2px 8px;
+  background:rgba(14, 20, 30, .82);
+  border-radius:8px;
+  font-size:.7rem;
+  font-weight:600;
   color:var(--muted);
-  letter-spacing:.14em;
+  letter-spacing:.12em;
   line-height:1;
   text-transform:uppercase;
   z-index:1;
-  transform:translateY(-4px);
-  border:1px solid rgba(255,255,255,.06);
-  box-shadow:0 10px 28px rgba(4, 6, 12, .4);
+  transform:translateY(-2px);
+  border:1px solid rgba(255,255,255,.05);
+  box-shadow:0 6px 16px rgba(4, 6, 12, .32);
 }
 body[data-theme="light"] .difficulty-label{
-  background:rgba(255,255,255,.9);
+  background:rgba(255,255,255,.92);
   border-color:rgba(15,23,42,.08);
-  box-shadow:0 12px 26px rgba(15,23,42,.08);
+  box-shadow:0 8px 18px rgba(15,23,42,.08);
 }
 .difficulty-slider{
   --thumb-size:clamp(22px, 4vw, 28px);
@@ -615,29 +641,26 @@ body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .editor-pane{
   display:flex;
   flex-direction:column;
-  gap:12px;
+  gap:10px;
   min-height:var(--adv-box-min);
-  background:
-    radial-gradient(140% 160% at 100% 0%, var(--editor-glow), transparent 72%),
-    var(--panel);
+  background:var(--panel-2);
   border:1px solid var(--field-border);
-  border-radius:18px;
-  padding:18px;
-  box-shadow:0 16px 36px rgba(4, 6, 14, .38);
+  border-radius:10px;
+  padding:16px;
+  box-shadow:0 8px 20px rgba(5,8,17,.22);
 }
 body[data-theme="light"] .editor-pane{
-  background:
-    radial-gradient(160% 200% at 100% 0%, var(--editor-glow), transparent 72%),
-    var(--panel-2);
-  border-color:rgba(15,23,42,.08);
-  box-shadow:0 16px 28px rgba(15,23,42,.1);
+  background:var(--panel);
+  border-color:var(--border);
+  box-shadow:0 6px 16px rgba(15,23,42,.12);
 }
 .editor-pane__header{
   display:flex;
   flex-wrap:wrap;
   gap:6px 12px;
-  align-items:baseline;
+  align-items:center;
   justify-content:space-between;
+  margin-bottom:10px;
 }
 .editor-pane__title{
   font-size:.78rem;
@@ -647,15 +670,17 @@ body[data-theme="light"] .editor-pane{
   color:var(--muted);
 }
 .editor-pane__hint{
-  font-size:.78rem;
+  font-size:.8rem;
   color:var(--muted);
   opacity:.85;
+  margin-left:auto;
+  text-align:right;
 }
 .editor-pane textarea{
   width:100%;
   min-height:var(--adv-box-min);
-  border-radius:12px;
-  padding:14px 16px;
+  border-radius:8px;
+  padding:12px 14px;
   border:1px solid var(--field-border);
   background:var(--field);
   color:var(--text);
@@ -675,16 +700,18 @@ body[data-theme="light"] .editor-pane textarea{
 }
 .editor-pane .mirror-box{
   border:1px solid var(--field-border);
-  background:var(--field);
-  border-radius:12px;
-  padding:0;
+  background:var(--panel);
+  border-radius:8px;
+  padding:12px;
   display:flex;
   min-height:var(--adv-box-min);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+  box-shadow:0 4px 12px rgba(5,8,17,.18);
   transition:border-color .15s ease, box-shadow .2s ease;
 }
 body[data-theme="light"] .editor-pane .mirror-box{
-  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+  background:var(--panel-2);
+  border-color:var(--border);
+  box-shadow:0 4px 12px rgba(15,23,42,.12);
 }
 .editor-pane .mirror-box[data-empty="true"]::after{
   content:"Waiting for generated quiz…";
@@ -692,7 +719,7 @@ body[data-theme="light"] .editor-pane .mirror-box{
   color:var(--muted);
   letter-spacing:.02em;
   margin:auto;
-  padding:0 16px;
+  padding:0 12px;
   text-align:center;
   opacity:.7;
   display:none;
@@ -701,7 +728,7 @@ body[data-theme="light"] .editor-pane .mirror-box{
 .editor-pane .mirror-box textarea{
   border:0;
   background:transparent;
-  padding:14px 16px;
+  padding:0;
   width:100%;
   line-height:1.45;
   resize:vertical;
@@ -740,10 +767,6 @@ body[data-theme="light"] .editor-pane .mirror-box{
   .mirror-toggle-label{ font-size:.85rem; }
   .mirror-toggle input{ transform:scale(1.05); }
 }
-@media (max-width:560px){
-  .gen-toolbar{grid-template-columns:1fr;}
-}
-
 .grid{display:grid; grid-template-columns:1fr 1fr; gap:16px}
  @media (max-width:880px){.grid{grid-template-columns:1fr}}
 
@@ -756,7 +779,7 @@ body[data-theme="light"] .editor-pane .mirror-box{
   border:1px solid var(--field-border);
   background:var(--field);
   color:var(--text);
-  border-radius:12px;
+  border-radius:8px;
   padding:12px 12px;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
   transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
@@ -777,7 +800,7 @@ body[data-theme="light"] .editor-pane .mirror-box{
 .gap{gap:12px}
 .btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
-  color:var(--text); padding:12px 16px; border-radius:14px; cursor:pointer; min-width:112px;
+  color:var(--text); padding:12px 16px; border-radius:10px; cursor:pointer; min-width:112px;
   transition:transform .04s ease, box-shadow .2s ease, filter .15s ease, background-color .15s ease;
   line-height:1.2;
   display:inline-flex; align-items:center; justify-content:center;

--- a/public/styles.css
+++ b/public/styles.css
@@ -247,6 +247,28 @@ body[data-theme="light"] .gen-toolbar{
   transition:background .15s ease, border-color .15s ease, box-shadow .18s ease;
 }
 body[data-theme="light"] .toolbar-input{ background:var(--panel); }
+.toolbar-input:-webkit-autofill,
+.number-wrap .toolbar-input:-webkit-autofill{
+  -webkit-text-fill-color:var(--text);
+  -webkit-box-shadow:0 0 0 1000px var(--panel-2) inset;
+  box-shadow:0 0 0 1000px var(--panel-2) inset;
+  caret-color:var(--text);
+}
+body[data-theme="light"] .toolbar-input:-webkit-autofill,
+body[data-theme="light"] .number-wrap .toolbar-input:-webkit-autofill{
+  -webkit-box-shadow:0 0 0 1000px var(--panel) inset;
+  box-shadow:0 0 0 1000px var(--panel) inset;
+}
+.toolbar-input:-moz-autofill,
+.number-wrap .toolbar-input:-moz-autofill{
+  box-shadow:0 0 0 1000px var(--panel-2) inset;
+  color:var(--text);
+  -moz-text-fill-color:var(--text);
+}
+body[data-theme="light"] .toolbar-input:-moz-autofill,
+body[data-theme="light"] .number-wrap .toolbar-input:-moz-autofill{
+  box-shadow:0 0 0 1000px var(--panel) inset;
+}
 .toolbar-input:hover{ background:var(--field-hover); border-color:var(--border); }
 .toolbar-input:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow); }
 .gen-toolbar #countInput{ text-align:center; }
@@ -1060,8 +1082,17 @@ body.is-quiz .hero{ /* transform: scale(.96); opacity:.9; */ }
 .modal__body em{ font-style:normal; font-weight:600; color:var(--muted) }
 
 /* Update banner */
-.update-banner{ display:flex; align-items:center; gap:10px; padding:8px 10px; margin:-4px 0 8px 0; border:1px solid var(--field-border); background:var(--panel-2); border-radius:10px }
-.update-banner.hidden{ display:none }
+.update-banner{
+  display:none;
+  align-items:center;
+  gap:10px;
+  padding:8px 10px;
+  margin:-4px 0 8px 0;
+  border:1px solid var(--field-border);
+  background:var(--panel-2);
+  border-radius:10px;
+}
+.update-banner:not(.hidden){ display:flex; }
 
 /* Question Types (Options) mobile-friendly chips */
 .qt-row{ align-items:center }

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,6 +22,8 @@
   --field-hover:#121a27;
   --focus-shadow:0 0 0 3px rgba(126, 163, 255, .35);
   --radius-lg:20px;
+  --toolbar-glow:rgba(122, 162, 255, .16);
+  --editor-glow:rgba(122, 162, 255, .12);
 }
 
 body[data-theme="light"]{
@@ -44,6 +46,8 @@ body[data-theme="light"]{
   --field-border:#cfd8ea;
   --field-hover:#e8edf6;
   --focus-shadow:0 0 0 3px rgba(110, 163, 255, .35);
+  --toolbar-glow:rgba(36, 92, 255, .12);
+  --editor-glow:rgba(36, 92, 255, .08);
 }
 
 *{box-sizing:border-box}
@@ -120,99 +124,160 @@ body[data-theme="dark"] .site-header .brand-link{
 
 /* Generate toolbar */
 .gen-toolbar{
-  --toolbar-gap:clamp(16px, 3.6vw, 24px);
-  --toolbar-input-height:48px;
-  background:var(--panel);
-  border:1px solid var(--field-border);
-  border-radius:var(--radius-lg, 20px);
-  padding:clamp(20px, 4vw, 26px);
-  margin:0 auto 16px;
-  max-width:960px;
-  box-shadow:var(--shadow-xs);
-}
-.gen-toolbar__layout{
+  --toolbar-control-height:clamp(48px, 5.8vw, 58px);
+  --toolbar-gap:clamp(16px, 2.8vw, 24px);
   display:grid;
+  grid-template-columns:minmax(220px, 1.15fr) minmax(260px, 1fr) auto auto;
+  align-items:end;
   gap:var(--toolbar-gap);
-  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
-  align-items:end;
+  background:
+    radial-gradient(140% 180% at 100% 0%, var(--toolbar-glow), transparent 68%),
+    linear-gradient(180deg, rgba(255,255,255,.04), rgba(0,0,0,.18)),
+    var(--panel);
+  border:1px solid var(--field-border);
+  border-radius:clamp(18px, 3.4vw, 26px);
+  padding:26px clamp(16px, 4vw, 28px) 20px;
+  margin:0 auto 12px;
+  max-width:900px;
+  box-shadow:0 18px 40px rgba(5, 8, 17, .45);
 }
-.gen-toolbar__layout > *{ min-width:0; }
-@media (min-width:900px){
-  .gen-toolbar__layout > .topic-field{ grid-column:span 2; }
+body[data-theme="light"] .gen-toolbar{
+  background:
+    radial-gradient(160% 200% at 100% 0%, var(--toolbar-glow), transparent 72%),
+    linear-gradient(180deg, rgba(255,255,255,.92), rgba(215,224,250,.72)),
+    var(--panel);
+  box-shadow:0 18px 32px rgba(15,23,42,.12);
 }
-.toolbar-duo{
-  display:grid;
-  gap:12px;
-  grid-template-columns:minmax(220px, 1fr) minmax(120px, .75fr);
-  align-items:end;
-  min-width:0;
+.gen-toolbar > *{ min-width:0; }
+.gen-toolbar > button.btn{
+  align-self:stretch;
+  justify-self:end;
+  min-width:140px;
+  height:var(--toolbar-control-height);
+  padding:0 clamp(18px, 4vw, 26px);
+  font-weight:600;
+  letter-spacing:.01em;
+  transition:transform .12s ease, box-shadow .2s ease;
 }
-@media (max-width:880px){
-  .toolbar-duo{ grid-template-columns:1fr; }
+.gen-toolbar > button.btn:hover{
+  transform:translateY(-1px);
+  box-shadow:0 12px 28px rgba(8, 12, 20, .38);
 }
-.toolbar-actions{
+body[data-theme="light"] .gen-toolbar > button.btn:hover{
+  box-shadow:0 12px 24px rgba(15,23,42,.15);
+}
+.gen-toolbar > button.btn:active{
+  transform:translateY(0);
+  box-shadow:none;
+}
+.gen-toolbar > button.btn:focus-visible{
+  transform:translateY(0);
+}
+.gen-toolbar .toolbar-pair{
   display:flex;
-  gap:12px;
-  justify-content:flex-end;
   align-items:center;
-  min-width:0;
+  gap:16px;
+  min-width:260px;
 }
-.toolbar-actions .btn{
-  flex:0 0 auto;
-  min-width:132px;
-  height:var(--toolbar-input-height);
+.gen-toolbar .toolbar-field{ flex:1 1 220px; min-width:160px; height:var(--toolbar-control-height); }
+.gen-toolbar .toolbar-field.narrow{ flex:1 1 160px; min-width:140px; }
+.gen-toolbar .toolbar-pair .toolbar-field.narrow{ flex:1 1 160px; min-width:140px; }
+.gen-toolbar .toolbar-pair .number-wrap{ width:100%; }
+.gen-toolbar .toolbar-pair .difficulty-stack,
+.gen-toolbar .difficulty-stack{
+  flex:1 1 auto;
+  align-items:center;
+  height:var(--toolbar-control-height);
+  padding:0 4px;
 }
-@media (max-width:880px){
-  .toolbar-actions{
+.gen-toolbar #generateBtn,
+.gen-toolbar #optionsBtn{ min-width:0; }
+@media (max-width:1024px){
+  .gen-toolbar{
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+  .gen-toolbar > button.btn{
+    justify-self:stretch;
+  }
+}
+@media (max-width:720px){
+  .gen-toolbar{
+    grid-template-columns:minmax(0, 1fr);
+    padding:24px clamp(14px, 6vw, 24px);
+  }
+  .gen-toolbar .toolbar-pair{
     flex-direction:column;
     align-items:stretch;
-    justify-content:stretch;
+    gap:14px;
   }
-  .toolbar-actions .btn{
-    min-width:0;
+  .gen-toolbar > button.btn{
     width:100%;
   }
+}
+@media (max-width:480px){
+  .gen-toolbar{ --toolbar-control-height:clamp(48px, 14vw, 62px); }
 }
 .toolbar-field{
   position:relative;
   display:flex;
   align-items:center;
-  min-width:0;
-  width:100%;
-  height:var(--toolbar-input-height, 48px);
+  flex:1 1 auto;
+  min-width:160px;
+  height:var(--toolbar-control-height, 52px);
 }
 .toolbar-field > .toolbar-input{
   flex:1 1 auto;
   width:100%;
-  height:100%;
 }
+.toolbar-field.narrow{ flex:1 1 150px; min-width:120px; }
 .toolbar-label{
   position:absolute;
-  bottom:100%;
+  bottom:calc(100% - 6px);
   left:18px;
-  padding:0;
-  background:transparent;
-  border-radius:0;
-  font-size:.75rem;
-  font-weight:600;
+  padding:4px 10px;
+  background:rgba(11, 16, 24, .78);
+  border-radius:999px;
+  font-size:.68rem;
+  font-weight:700;
   color:var(--muted);
-  letter-spacing:.01em;
-  line-height:1.1;
+  letter-spacing:.14em;
+  line-height:1;
+  text-transform:uppercase;
   z-index:1;
-  transform:translateY(-2px);
+  transform:translateY(-4px);
+  border:1px solid rgba(255,255,255,.06);
+  box-shadow:0 10px 28px rgba(4, 6, 12, .4);
+}
+body[data-theme="light"] .toolbar-label{
+  background:rgba(255,255,255,.9);
+  border-color:rgba(15,23,42,.08);
+  box-shadow:0 12px 26px rgba(15,23,42,.08);
 }
 .toolbar-input{
   border:1px solid var(--field-border);
-  background:var(--field);
+  background:linear-gradient(180deg, var(--panel-2), var(--field));
   color:var(--text);
-  border-radius:12px;
+  border-radius:14px;
   height:100%;
-  min-height:var(--toolbar-input-height, 48px);
-  padding:0 14px;
-  transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
+  padding:0 16px;
+  font-size:1rem;
+  transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
 }
-.toolbar-input:hover{background:var(--field-hover); border-color:var(--border)}
-.toolbar-input:focus{outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow)}
+.toolbar-input:hover{
+  background:var(--field-hover);
+  border-color:var(--border);
+}
+.toolbar-input:focus{
+  outline:2px solid var(--ring);
+  outline-offset:2px;
+  box-shadow:var(--focus-shadow);
+}
+.toolbar-field:focus-within .toolbar-label,
+.difficulty-stack:focus-within .difficulty-label{
+  color:var(--text);
+  border-color:var(--ring);
+  box-shadow:0 0 0 3px rgba(126, 163, 255, .28);
+}
 .gen-toolbar #countInput{ text-align:center; }
 .number-wrap{
   position:relative;
@@ -220,13 +285,20 @@ body[data-theme="dark"] .site-header .brand-link{
   display:flex;
   align-items:stretch;
   border:1px solid var(--field-border);
-  background:var(--field);
-  border-radius:12px;
+  background:linear-gradient(180deg, var(--panel-2), var(--field));
+  border-radius:14px;
   overflow:hidden;
-  transition:background .15s ease, border-color .15s ease, box-shadow .15s ease;
+  transition:background .15s ease, border-color .15s ease, box-shadow .2s ease;
   height:100%;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
 }
-.number-wrap:hover{ background:var(--field-hover); border-color:var(--border); }
+body[data-theme="light"] .number-wrap{
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.04);
+}
+.number-wrap:hover{
+  background:var(--field-hover);
+  border-color:var(--border);
+}
 .number-wrap:focus-within{
   outline:2px solid var(--ring);
   outline-offset:2px;
@@ -237,7 +309,7 @@ body[data-theme="dark"] .site-header .brand-link{
   width:100%;
   border:0;
   background:transparent;
-  padding:0 12px;
+  padding:0 16px;
   height:100%;
   color:var(--text);
   box-shadow:none;
@@ -260,7 +332,7 @@ body[data-theme="dark"] .site-header .brand-link{
   flex:0 0 auto;
   display:flex;
   flex-direction:column;
-  width:20px;
+  width:28px;
   border-left:1px solid var(--field-border);
   background:var(--panel-2);
   height:100%;
@@ -270,20 +342,22 @@ body[data-theme="dark"] .site-header .brand-link{
   border:0;
   background:transparent;
   color:var(--muted);
-  font-size:.45rem;
+  font-size:.6rem;
+  font-weight:700;
   line-height:1;
   display:flex;
   align-items:center;
   justify-content:center;
   cursor:pointer;
+  letter-spacing:.08em;
   transition:background .12s ease, color .12s ease;
 }
 .stepper:first-child{
   border-bottom:1px solid var(--field-border);
-  border-top-right-radius:12px;
+  border-top-right-radius:14px;
 }
 .stepper:last-child{
-  border-bottom-right-radius:12px;
+  border-bottom-right-radius:14px;
 }
 .stepper:hover{
   background:var(--field-hover);
@@ -302,48 +376,56 @@ body[data-theme="dark"] .site-header .brand-link{
   display:flex;
   align-items:center;
   justify-content:center;
-  min-width:160px;
-  height:var(--toolbar-input-height, 48px);
-  padding:0 14px;
+  flex:1 1 auto;
+  min-width:180px;
+  height:var(--toolbar-control-height, 52px);
+  padding:0 20px;
+  border-radius:14px;
+  background:linear-gradient(180deg, var(--panel-2), var(--field));
   border:1px solid var(--field-border);
-  background:var(--field);
-  border-radius:12px;
-  transition:border-color .15s ease, background-color .15s ease, box-shadow .2s ease;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+  transition:border-color .15s ease, box-shadow .2s ease;
 }
-.difficulty-stack:hover{
-  background:var(--field-hover);
-  border-color:var(--border);
+body[data-theme="light"] .difficulty-stack{
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.04);
 }
+.difficulty-stack:hover{ border-color:var(--border); }
 .difficulty-stack:focus-within{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
+  border-color:var(--ring);
   box-shadow:var(--focus-shadow);
 }
 .difficulty-slider{ width:100%; }
 .difficulty-label{
   position:absolute;
-  bottom:100%;
-  left:18px;
-  padding:0;
-  background:transparent;
-  border-radius:0;
-  font-size:.75rem;
-  font-weight:600;
+  bottom:calc(100% - 6px);
+  left:22px;
+  padding:4px 10px;
+  background:rgba(11, 16, 24, .78);
+  border-radius:999px;
+  font-size:.68rem;
+  font-weight:700;
   color:var(--muted);
-  letter-spacing:.01em;
-  line-height:1.1;
+  letter-spacing:.14em;
+  line-height:1;
+  text-transform:uppercase;
   z-index:1;
-  transform:translateY(-2px);
+  transform:translateY(-4px);
+  border:1px solid rgba(255,255,255,.06);
+  box-shadow:0 10px 28px rgba(4, 6, 12, .4);
+}
+body[data-theme="light"] .difficulty-label{
+  background:rgba(255,255,255,.9);
+  border-color:rgba(15,23,42,.08);
+  box-shadow:0 12px 26px rgba(15,23,42,.08);
 }
 .difficulty-slider{
-  --slider-width: 140px;
-  --thumb-size: 22px;
-  --track-height: 8px;
-  --dot-size: 3px;
+  --thumb-size:clamp(22px, 4vw, 28px);
+  --track-height:10px;
+  --dot-size:4px;
   position:relative;
-  width:min(var(--slider-width), 100%);
+  width:100%;
   max-width:100%;
-  padding:calc(var(--thumb-size) / 2) 0;
+  padding:calc(var(--thumb-size) / 2 + 2px) 0;
 }
 .difficulty-slider input[type="range"]{
   width:100%;
@@ -375,19 +457,27 @@ body[data-theme="dark"] .site-header .brand-link{
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
-  border:2px solid var(--panel);
-  box-shadow:var(--shadow-xs);
+  border:3px solid rgba(11, 16, 24, .72);
+  box-shadow:0 10px 24px rgba(122,162,255,.36);
   margin-top:calc((var(--track-height) - var(--thumb-size)) / 2);
-  transition:transform .15s ease;
+  transition:transform .15s ease, box-shadow .2s ease;
+}
+body[data-theme="light"] .difficulty-slider input[type="range"]::-webkit-slider-thumb{
+  border-color:rgba(255,255,255,.9);
+  box-shadow:0 10px 22px rgba(36,92,255,.28);
 }
 .difficulty-slider input[type="range"]::-moz-range-thumb{
   width:var(--thumb-size);
   height:var(--thumb-size);
   border-radius:50%;
   background:var(--primary);
-  border:2px solid var(--panel);
-  box-shadow:var(--shadow-xs);
-  transition:transform .15s ease;
+  border:3px solid rgba(11, 16, 24, .72);
+  box-shadow:0 10px 24px rgba(122,162,255,.36);
+  transition:transform .15s ease, box-shadow .2s ease;
+}
+body[data-theme="light"] .difficulty-slider input[type="range"]::-moz-range-thumb{
+  border-color:rgba(255,255,255,.9);
+  box-shadow:0 10px 22px rgba(36,92,255,.28);
 }
 .difficulty-slider input[type="range"]:focus-visible{
   outline:2px solid var(--ring);
@@ -395,10 +485,8 @@ body[data-theme="dark"] .site-header .brand-link{
 }
 .difficulty-slider input[type="range"]:active::-webkit-slider-thumb,
 .difficulty-slider input[type="range"]:active::-moz-range-thumb{
-  transform:scale(1.08);
-}
-.difficulty-slider:focus-within .difficulty-track::before{
-  border-color:var(--primary);
+  transform:scale(1.06);
+  box-shadow:0 12px 26px rgba(122,162,255,.42);
 }
 .difficulty-track{
   position:absolute;
@@ -413,11 +501,22 @@ body[data-theme="dark"] .site-header .brand-link{
   content:"";
   position:absolute;
   inset:0;
-  background:var(--panel-2);
-  border:1px solid var(--field-border);
+  background:linear-gradient(90deg, rgba(122,162,255,.22), rgba(122,162,255,.05) 80%);
+  border:1px solid rgba(122,162,255,.28);
   border-radius:999px;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.2);
   z-index:0;
-  transition:border-color .2s ease, background .2s ease;
+  transition:border-color .2s ease, background .2s ease, box-shadow .2s ease;
+}
+body[data-theme="light"] .difficulty-track::before{
+  background:linear-gradient(90deg, rgba(36,92,255,.2), rgba(36,92,255,.08) 82%);
+  border-color:rgba(36,92,255,.24);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.55);
+}
+.difficulty-slider:hover .difficulty-track::before,
+.difficulty-stack:focus-within .difficulty-track::before{
+  border-color:var(--ring);
+  box-shadow:inset 0 0 0 1px rgba(126,163,255,.45);
 }
 .difficulty-dot{
   position:absolute;
@@ -425,9 +524,10 @@ body[data-theme="dark"] .site-header .brand-link{
   width:var(--dot-size);
   height:var(--dot-size);
   border-radius:50%;
-  background:var(--field-border);
+  background:rgba(255,255,255,.38);
   transform:translate(-50%, -50%);
 }
+body[data-theme="light"] .difficulty-dot{ background:rgba(15,23,42,.32); }
 .difficulty-track .difficulty-dot:nth-child(1){ left:25%; }
 .difficulty-track .difficulty-dot:nth-child(2){ left:50%; }
 .difficulty-track .difficulty-dot:nth-child(3){ left:75%; }
@@ -472,17 +572,18 @@ body[data-theme="dark"] .site-header .brand-link{
 .adv-title{margin:0; font-size:15px}
 .adv-title-right{display:flex; align-items:baseline; gap:10px; justify-content:space-between}
 .adv-title-right .spacer{flex:1 1 auto}
-:root{ --adv-box-min: 260px; }
-.adv-panels{
-  display:grid;
-  gap:16px;
-  grid-template-columns:minmax(0, 1.2fr) minmax(0, .8fr);
-  align-items:stretch;
+.adv-panels{display:grid; grid-template-columns:minmax(0, 2fr) minmax(0, 1fr); gap:16px}
+.adv-panels.is-ie-mode{grid-template-columns:1fr;}
+.adv-panels.is-ie-mode .adv-right{grid-column:1;}
+.adv-left, .adv-right{min-width:0}
+@media (max-width:1080px){
+  .adv-panels{ grid-template-columns:repeat(2, minmax(0, 1fr)); }
 }
-.adv-panels.is-ie-mode{ grid-template-columns:1fr; }
-.adv-panels.is-ie-mode .adv-right{ grid-column:auto; }
-.adv-left, .adv-right{ min-width:0 }
-.adv-actions{display:grid; grid-template-columns: 2fr 1fr; gap:12px; margin-top:10px}
+@media (max-width:900px){
+  .adv-panels{ grid-template-columns:minmax(0, 1fr); }
+  .adv-panels .adv-right{ grid-column:1; }
+}
+.adv-actions{display:grid; grid-template-columns:minmax(0, 1.2fr) minmax(0, 0.9fr); gap:16px; margin-top:12px}
 .adv-actions .row{margin-top:0}
 /* Make Quiz Editor action buttons equal width within their rows */
 .adv-actions .row:first-child .btn{ flex:1 1 0; min-width:0 }
@@ -502,9 +603,114 @@ body[data-theme="dark"] .site-header .brand-link{
 .adv-group.run{ flex: 1 1 260px; justify-content:flex-end }
 .adv-group .btn{ flex: 1 1 160px; min-width: 0 }
 .adv-group.run #startBtn{ flex: 1.2 1 200px }
+@media (max-width: 900px){
+  .adv-actions{ grid-template-columns:1fr; }
+  .adv-group.run{ justify-content:flex-start; }
+}
 @media (max-width: 600px){
   .adv-group.files, .adv-group.run{ flex-basis: 100%; justify-content:stretch }
   .adv-group .btn{ flex-basis: 100% }
+}
+
+.editor-pane{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  min-height:var(--adv-box-min);
+  background:
+    radial-gradient(140% 160% at 100% 0%, var(--editor-glow), transparent 72%),
+    var(--panel);
+  border:1px solid var(--field-border);
+  border-radius:18px;
+  padding:18px;
+  box-shadow:0 16px 36px rgba(4, 6, 14, .38);
+}
+body[data-theme="light"] .editor-pane{
+  background:
+    radial-gradient(160% 200% at 100% 0%, var(--editor-glow), transparent 72%),
+    var(--panel-2);
+  border-color:rgba(15,23,42,.08);
+  box-shadow:0 16px 28px rgba(15,23,42,.1);
+}
+.editor-pane__header{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px 12px;
+  align-items:baseline;
+  justify-content:space-between;
+}
+.editor-pane__title{
+  font-size:.78rem;
+  font-weight:700;
+  letter-spacing:.14em;
+  text-transform:uppercase;
+  color:var(--muted);
+}
+.editor-pane__hint{
+  font-size:.78rem;
+  color:var(--muted);
+  opacity:.85;
+}
+.editor-pane textarea{
+  width:100%;
+  min-height:var(--adv-box-min);
+  border-radius:12px;
+  padding:14px 16px;
+  border:1px solid var(--field-border);
+  background:var(--field);
+  color:var(--text);
+  line-height:1.45;
+  resize:vertical;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+  transition:border-color .15s ease, box-shadow .2s ease, background .2s ease;
+}
+body[data-theme="light"] .editor-pane textarea{
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+}
+.editor-pane textarea:hover{ border-color:var(--border); }
+.editor-pane textarea:focus{
+  outline:2px solid var(--ring);
+  outline-offset:2px;
+  box-shadow:var(--focus-shadow);
+}
+.editor-pane .mirror-box{
+  border:1px solid var(--field-border);
+  background:var(--field);
+  border-radius:12px;
+  padding:0;
+  display:flex;
+  min-height:var(--adv-box-min);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+  transition:border-color .15s ease, box-shadow .2s ease;
+}
+body[data-theme="light"] .editor-pane .mirror-box{
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+}
+.editor-pane .mirror-box[data-empty="true"]::after{
+  content:"Waiting for generated quiz…";
+  font-size:.82rem;
+  color:var(--muted);
+  letter-spacing:.02em;
+  margin:auto;
+  padding:0 16px;
+  text-align:center;
+  opacity:.7;
+  display:none;
+}
+.editor-pane .mirror-box[data-empty="true"][data-on="true"]::after{ display:block; }
+.editor-pane .mirror-box textarea{
+  border:0;
+  background:transparent;
+  padding:14px 16px;
+  width:100%;
+  line-height:1.45;
+  resize:vertical;
+  color:var(--text);
+}
+.editor-pane .mirror-box textarea:focus{
+  outline:2px solid var(--ring);
+  outline-offset:2px;
+  box-shadow:var(--focus-shadow);
 }
 
 /* Copy/Export row as a clean two-up grid */
@@ -512,82 +718,30 @@ body[data-theme="dark"] .site-header .brand-link{
 @media (max-width: 600px){ .advanced-actions{ grid-template-columns: 1fr } }
 
 /* Keep boxes visually in sync */
-.adv-panels .editor,
-.adv-panels .mirror-box{ min-height: var(--adv-box-min); }
-.adv-panels .editor{ width:100%; height:auto; line-height:1.45 }
-.mirror-box{ border:1px solid var(--field-border); background:var(--field); border-radius:12px; padding:0; display:flex; }
-.mirror-box textarea{ border:0; background:transparent; padding:16px; width:100%; height:auto; line-height:1.5; resize:vertical }
-.mirror-box[data-on="false"]{ display:none }
-/* Mirror empty placeholder */
-.mirror-box[data-empty="true"]{ position:relative }
-.mirror-box[data-empty="true"]::before{
-  content:'Generated quiz lines will appear here…';
-  position:absolute; inset:16px 18px auto 18px; color:var(--muted); opacity:.8; pointer-events:none; font-size:.9em;
-}
-
-.ie-pane{
-  display:flex;
-  flex-direction:column;
-  gap:12px;
-  padding:16px;
-  background:var(--panel-2);
-  border:1px solid var(--field-border);
-  border-radius:16px;
-  box-shadow:var(--shadow-xs);
-  min-height:100%;
-}
-body[data-theme="light"] .ie-pane{ background:var(--panel); }
-.ie-pane__header{
-  display:flex;
-  align-items:baseline;
-  justify-content:space-between;
-  gap:12px;
-}
-.ie-pane__title{
-  font-size:.95rem;
-  font-weight:600;
-  letter-spacing:.015em;
-}
-.ie-pane__hint{
-  color:var(--muted);
-  font-size:.75rem;
-  line-height:1.3;
-}
-.ie-pane textarea{
-  flex:1 1 auto;
-  min-height:var(--adv-box-min);
-  padding:16px;
-  border-radius:12px;
-}
-.ie-pane[data-pane="mirror"] .mirror-box{
-  flex:1 1 auto;
-}
-.ie-pane[data-pane="mirror"] .mirror-box textarea{
-  height:100%;
-}
-
-/* Keep focus ring visible when focusing textarea inside mirror */
-.mirror-box textarea:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow) }
+:root{ --adv-box-min: 280px; }
+.editor-pane textarea,
+.editor-pane .mirror-box{ min-height: var(--adv-box-min); }
+.editor-pane .mirror-box[data-on="false"]{ display:none }
 
 /* Mirror toggle size harmony */
 .opt-switch.small{ padding:6px 8px }
 .opt-switch.small input{ transform:scale(0.95) }
 
-/* Stack below ~768px */
 @media (max-width: 768px){
   .adv-head{ grid-template-columns: 1fr; align-items:center }
   .adv-title-right{ justify-content:flex-start; gap:12px }
-  .adv-panels{ grid-template-columns: 1fr }
-  .adv-actions{ grid-template-columns: 1fr }
-  .adv-panels .editor,
-  .adv-panels .mirror-box{ min-height: 0 }
 }
 @media (max-width: 600px){
+  .editor-pane{ padding:16px; }
+  .editor-pane__header{ align-items:flex-start; }
   .adv-mode-toggle{ width:100%; justify-content:space-between }
   .adv-mode-btn{ flex:1 1 0; padding:8px 12px; text-align:center }
   .mirror-toggle{ width:100%; justify-content:space-between; padding:8px 12px }
   .mirror-toggle-label{ font-size:.85rem; }
   .mirror-toggle input{ transform:scale(1.05); }
+}
+@media (max-width:560px){
+  .gen-toolbar{grid-template-columns:1fr;}
 }
 
 .grid{display:grid; grid-template-columns:1fr 1fr; gap:16px}

--- a/public/styles.css
+++ b/public/styles.css
@@ -254,16 +254,17 @@ body[data-theme="light"] .toolbar-input{ background:var(--panel); }
   background:var(--panel-2);
   border:1px solid var(--field-border);
   border-radius:var(--radius-control);
+  -webkit-background-clip:padding-box;
   background-clip:padding-box;
   -webkit-box-shadow:0 0 0 1000px var(--panel-2) inset;
   box-shadow:0 0 0 1000px var(--panel-2) inset;
 }
 body[data-theme="light"] .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus),
 body[data-theme="light"] .number-wrap .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus){
+  border-color:var(--border);
   background:var(--panel);
   -webkit-box-shadow:0 0 0 1000px var(--panel) inset;
   box-shadow:0 0 0 1000px var(--panel) inset;
-  border-color:var(--border);
 }
 .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus),
 .number-wrap .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus){
@@ -273,12 +274,25 @@ body[data-theme="light"] .number-wrap .toolbar-input:is(:-webkit-autofill, :-web
   background:var(--panel-2);
   border:1px solid var(--field-border);
   border-radius:var(--radius-control);
+  -webkit-background-clip:padding-box;
+  background-clip:padding-box;
 }
 body[data-theme="light"] .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus),
 body[data-theme="light"] .number-wrap .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus){
   box-shadow:0 0 0 1000px var(--panel) inset;
   background:var(--panel);
   border-color:var(--border);
+}
+.number-wrap .toolbar-input:is(:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus){
+  border:0;
+  background:transparent;
+  -webkit-box-shadow:none;
+  box-shadow:none;
+}
+.number-wrap .toolbar-input:is(:-moz-autofill, :-moz-autofill:hover, :-moz-autofill:focus){
+  border:0;
+  background:transparent;
+  box-shadow:none;
 }
 .toolbar-input:hover{ background:var(--field-hover); border-color:var(--border); }
 .toolbar-input:focus{ outline:2px solid var(--ring); outline-offset:2px; box-shadow:var(--focus-shadow); }


### PR DESCRIPTION
## Summary
- Reworked the generator toolbar markup into a responsive grid layout and grouped the action buttons for consistency across breakpoints.
- Updated generator field styling, including the difficulty slider container, to align with the taller, padded controls.
- Wrapped the manual editor and mirror panes in new shells with headers and refreshed styling for clearer separation and responsive behavior.

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2ec938e208329bd797751be40a0be