### PR TITLE
Allow fallback quiz endpoint through CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ for = "/*"
   Permissions-Policy = "geolocation=(), microphone=(), camera=()"
   Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
   # Tighten CSP: only first-party resources are needed. The Support link is a plain href (no widget scripts/iframes).
-  Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
+  Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://eq-quiz.netlify.app; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
 
 # Ensure fresh HTML/app shell while allowing long-lived assets
 [[headers]]


### PR DESCRIPTION
## Summary
- allow the new default Netlify fallback endpoint in the Content Security Policy connect-src list so cross-origin quiz requests are permitted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5db4b3df08329bf8ba8281d26e060