### PR TITLE
Add rate limiting guard to quiz generator

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -12,6 +12,12 @@ Optional security:
 - ALLOWED_ORIGINS: Comma‑separated list of allowed origins for CORS, e.g.
   - `https://ez-quiz.app,https://staging.ez-quiz.app`
   - Leave empty to allow all origins (not recommended).
+  - Applied to both quiz generation and feedback mailer functions.
+- GENERATE_LIMIT: Per-IP request cap for `generate-quiz` (default `60`).
+- GENERATE_WINDOW_MS: Sliding window size in milliseconds for the rate limiter (default `900000`, i.e. 15 minutes).
+  - `Retry-After` responses are derived from this window; shorten it to offer quicker retries.
+- GENERATE_BEARER_TOKEN: Optional shared secret required in the `Authorization: Bearer <token>` header for quiz generation.
+  - Combine with Netlify redirects or an API gateway to keep the token private in zero-trust setups.
 
 AI Generation providers (optional):
 - AI_PROVIDER: `gemini`, `openai`, or `echo`

--- a/netlify/functions/generate-quiz.js
+++ b/netlify/functions/generate-quiz.js
@@ -5,138 +5,213 @@
 - Netlify Function: generate-quiz
 - POST /api/generate  { topic: string, count: number }
 - Returns: { lines: string }  // newline-separated quiz lines
-- 
+-
 - Requires env: GEMINI_API_KEY
   */
 
-const corsHeaders = {
-'Access-Control-Allow-Origin': '*', 
-'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
-
 const { generateLines } = require('./lib/providers.js');
 
-exports.handler = async (event) => {
-// Preflight
-if (event.httpMethod === 'OPTIONS') {
-return { statusCode: 204, headers: corsHeaders, body: '' };
+function parseAllowedOrigins() {
+  const raw = process.env.ALLOWED_ORIGINS || '';
+  return raw.split(',').map(s => s.trim()).filter(Boolean);
 }
 
-if (event.httpMethod !== 'POST') {
-return {
-statusCode: 405,
-headers: corsHeaders,
-body: JSON.stringify({ error: 'Method Not Allowed' }),
-};
+function getOrigin(headers) {
+  const h = headers || {};
+  return h.origin || h.Origin || '';
 }
 
-let payload;
-try { payload = JSON.parse(event.body || '{}'); } catch {
-return {
-statusCode: 400,
-headers: corsHeaders,
-body: JSON.stringify({ error: 'Invalid JSON' }),
-};
-}
-
-// Normalization + validation (non‑breaking)
-const topicRaw = (payload.topic == null ? '' : String(payload.topic)).trim();
-const topic = topicRaw || 'General knowledge';
-
-let count = payload.count;
-if (count == null) { count = 10; }
-const parsedCount = parseInt(count, 10);
-if (!Number.isFinite(parsedCount)) {
-  // Bad type for count — reject clearly
-  return {
-    statusCode: 400,
-    headers: corsHeaders,
-    body: JSON.stringify({ error: 'Invalid count: must be a number between 1 and 50' }),
+function makeCorsHeaders(origin) {
+  const H = {
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
   };
-}
-count = Math.max(1, Math.min(50, parsedCount));
-
-let types = undefined;
-if (payload.types !== undefined) {
-  if (!Array.isArray(payload.types)) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'Invalid types: must be an array of MC|TF|YN|MT' }),
-    };
-  }
-  const filtered = payload.types.filter(t => /^(MC|TF|YN|MT)$/i.test(String(t)));
-  // If caller provided types but none are valid, reject; otherwise pass filtered
-  if (payload.types.length && filtered.length === 0) {
-    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid types: use MC, TF, YN, MT' }) };
-  }
-  types = filtered;
+  if (origin) H['Access-Control-Allow-Origin'] = origin;
+  return H;
 }
 
-const difficulty = (payload.difficulty && String(payload.difficulty).toLowerCase()) || undefined;
-const provider = String(payload.provider || process.env.AI_PROVIDER || 'gemini');
-const model = String(payload.model || '');
-
-// Timeout guard so the function never hangs on upstream calls
-function withTimeout(promise, ms) {
-  return new Promise((resolve, reject) => {
-    const id = setTimeout(() => reject(Object.assign(new Error('Upstream timeout'), { status: 504 })), ms);
-    promise.then(v => { clearTimeout(id); resolve(v); }, e => { clearTimeout(id); reject(e); });
-  });
-}
-
-const TIMEOUT_MS = Math.max(8000, Math.min(20000, parseInt(process.env.GENERATE_TIMEOUT_MS || '15000', 10)));
-
-try {
-  const { title, lines, provider: usedProvider, model: usedModel } = await withTimeout(
-    generateLines({ provider, model, topic, count, types, difficulty, env: process.env }),
-    TIMEOUT_MS
-  );
-  return {
-    statusCode: 200,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title, lines, provider: usedProvider, model: usedModel, fallbackUsed: false }),
-  };
-} catch (err) {
-  const msg = String((err && err.message) || err || 'Error');
-  const is429 = msg.includes('429') || /quota|rate limit/i.test(msg) || (err && err.status===429);
-  const isTimeout = (err && (err.status === 504 || /timeout/i.test(msg)));
-
-  // Fallback to Gemini if primary provider failed and Gemini credentials exist
-  const primary = (provider || '').toLowerCase();
-  const canFallbackToGemini = primary !== 'gemini' && !!process.env.GEMINI_API_KEY;
-  if (canFallbackToGemini && !isTimeout) {
-    try {
-      const { title, lines, provider: usedProvider, model: usedModel } = await withTimeout(
-        generateLines({ provider: 'gemini', model: process.env.GEMINI_MODEL || 'gemini-2.0-flash', topic, count, types, difficulty, env: process.env }),
-        TIMEOUT_MS
-      );
-      return {
-        statusCode: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, lines, provider: usedProvider, model: usedModel, fallbackUsed: true, fallbackFrom: primary, errorPrimary: msg }),
-      };
-    } catch (fallbackErr) {
-      const fbMsg = String((fallbackErr && fallbackErr.message) || fallbackErr || 'Error');
-      return {
-        statusCode: isTimeout ? 504 : ((err && err.status) || (fallbackErr && fallbackErr.status) || (is429 ? 429 : 502)),
-        headers: { ...corsHeaders, ...(is429 ? { 'Retry-After': '30' } : {}), ...(isTimeout ? { 'Retry-After': '15' } : {}) },
-        body: JSON.stringify({ error: 'Generation failed', details: msg, fallback: { tried: 'gemini', details: fbMsg } }),
-      };
-    }
-  }
-
-  const statusFromError = err && err.status;
-  let statusCode = isTimeout ? 504 : (is429 ? 429 : statusFromError || 502);
-  if (statusCode === 404) {
-    statusCode = 502;
-  }
-
+function reply(statusCode, body, origin) {
+  const headers = makeCorsHeaders(origin);
   return {
     statusCode,
-    headers: { ...corsHeaders, ...(is429 ? { 'Retry-After': '30' } : {}), ...(isTimeout ? { 'Retry-After': '15' } : {}) },
-    body: JSON.stringify({ error: isTimeout ? 'Generation timed out' : 'Generation failed', details: msg, provider }),
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
   };
 }
+
+// Sliding window rate limit per IP (defaults: 60 requests / 15 minutes)
+const RL = new Map(); // ip -> [timestamps]
+const DEFAULT_LIMIT = 60;
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+
+function toPositiveInt(value, fallback) {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const LIMIT = toPositiveInt(process.env.GENERATE_LIMIT, DEFAULT_LIMIT);
+const WINDOW_MS = toPositiveInt(process.env.GENERATE_WINDOW_MS, DEFAULT_WINDOW_MS);
+const BEARER_TOKEN = process.env.GENERATE_BEARER_TOKEN ? String(process.env.GENERATE_BEARER_TOKEN) : '';
+
+function clientIp(event) {
+  const h = event.headers || {};
+  const xf = h['x-forwarded-for'] || h['X-Forwarded-For'] || '';
+  const ip = (Array.isArray(xf) ? xf[0] : String(xf).split(',')[0]).trim() || h['client-ip'] || h['x-nf-client-connection-ip'] || 'unknown';
+  return String(ip);
+}
+
+function rateLimited(event) {
+  if (!LIMIT) return false;
+  const now = Date.now();
+  const ip = clientIp(event);
+  const arr = RL.get(ip) || [];
+  const fresh = arr.filter(ts => now - ts < WINDOW_MS);
+  if (fresh.length >= LIMIT) return true;
+  fresh.push(now);
+  RL.set(ip, fresh);
+  if (RL.size > 500) {
+    for (const [k, list] of RL.entries()) {
+      const keep = list.filter(ts => now - ts < WINDOW_MS);
+      if (keep.length) RL.set(k, keep); else RL.delete(k);
+    }
+  }
+  return false;
+}
+
+function authorize(event) {
+  if (!BEARER_TOKEN) return true;
+  const h = event.headers || {};
+  const raw = h.authorization || h.Authorization || '';
+  if (!raw || typeof raw !== 'string') return false;
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith('bearer ')) return false;
+  const token = trimmed.slice(7).trim();
+  return token === BEARER_TOKEN;
+}
+
+exports.handler = async (event) => {
+  const allowedOrigins = parseAllowedOrigins();
+  const origin = getOrigin(event.headers);
+  const originAllowed = !origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin);
+
+  if (event.httpMethod === 'OPTIONS') {
+    if (!originAllowed) return reply(403, { error: 'Forbidden origin' }, '');
+    return reply(204, '', origin || (allowedOrigins.length === 0 ? '*' : ''));
+  }
+
+  if (!originAllowed) return reply(403, { error: 'Forbidden origin' }, '');
+
+  const responseOrigin = origin || (allowedOrigins.length === 0 ? '*' : '');
+
+  if (event.httpMethod !== 'POST') return reply(405, { error: 'Method Not Allowed' }, responseOrigin);
+
+  if (!authorize(event)) {
+    const res = reply(401, { error: 'Unauthorized' }, responseOrigin);
+    res.headers['WWW-Authenticate'] = 'Bearer';
+    return res;
+  }
+
+  if (rateLimited(event)) {
+    const retry = Math.ceil(WINDOW_MS / 1000);
+    const res = reply(429, { error: 'Rate limited' }, responseOrigin);
+    res.headers['Retry-After'] = String(retry);
+    return res;
+  }
+
+  let payload;
+  try { payload = JSON.parse(event.body || '{}'); } catch {
+    return reply(400, { error: 'Invalid JSON' }, responseOrigin);
+  }
+
+  // Normalization + validation (non‑breaking)
+  const topicRaw = (payload.topic == null ? '' : String(payload.topic)).trim();
+  const topic = topicRaw || 'General knowledge';
+
+  let count = payload.count;
+  if (count == null) { count = 10; }
+  const parsedCount = parseInt(count, 10);
+  if (!Number.isFinite(parsedCount)) {
+    return reply(400, { error: 'Invalid count: must be a number between 1 and 50' }, responseOrigin);
+  }
+  count = Math.max(1, Math.min(50, parsedCount));
+
+  let types = undefined;
+  if (payload.types !== undefined) {
+    if (!Array.isArray(payload.types)) {
+      return reply(400, { error: 'Invalid types: must be an array of MC|TF|YN|MT' }, responseOrigin);
+    }
+    const filtered = payload.types.filter(t => /^(MC|TF|YN|MT)$/i.test(String(t)));
+    if (payload.types.length && filtered.length === 0) {
+      return reply(400, { error: 'Invalid types: use MC, TF, YN, MT' }, responseOrigin);
+    }
+    types = filtered;
+  }
+
+  const difficulty = (payload.difficulty && String(payload.difficulty).toLowerCase()) || undefined;
+  const provider = String(payload.provider || process.env.AI_PROVIDER || 'gemini');
+  const model = String(payload.model || '');
+
+  // Timeout guard so the function never hangs on upstream calls
+  function withTimeout(promise, ms) {
+    return new Promise((resolve, reject) => {
+      const id = setTimeout(() => reject(Object.assign(new Error('Upstream timeout'), { status: 504 })), ms);
+      promise.then(v => { clearTimeout(id); resolve(v); }, e => { clearTimeout(id); reject(e); });
+    });
+  }
+
+  const TIMEOUT_MS = Math.max(8000, Math.min(20000, parseInt(process.env.GENERATE_TIMEOUT_MS || '15000', 10)));
+
+  const corsHeaders = makeCorsHeaders(responseOrigin);
+
+  try {
+    const { title, lines, provider: usedProvider, model: usedModel } = await withTimeout(
+      generateLines({ provider, model, topic, count, types, difficulty, env: process.env }),
+      TIMEOUT_MS
+    );
+    return {
+      statusCode: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, lines, provider: usedProvider, model: usedModel, fallbackUsed: false }),
+    };
+  } catch (err) {
+    const msg = String((err && err.message) || err || 'Error');
+    const is429 = msg.includes('429') || /quota|rate limit/i.test(msg) || (err && err.status === 429);
+    const isTimeout = err && (err.status === 504 || /timeout/i.test(msg));
+
+    // Fallback to Gemini if primary provider failed and Gemini credentials exist
+    const primary = (provider || '').toLowerCase();
+    const canFallbackToGemini = primary !== 'gemini' && !!process.env.GEMINI_API_KEY;
+    if (canFallbackToGemini && !isTimeout) {
+      try {
+        const { title, lines, provider: usedProvider, model: usedModel } = await withTimeout(
+          generateLines({ provider: 'gemini', model: process.env.GEMINI_MODEL || 'gemini-2.0-flash', topic, count, types, difficulty, env: process.env }),
+          TIMEOUT_MS
+        );
+        return {
+          statusCode: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, lines, provider: usedProvider, model: usedModel, fallbackUsed: true, fallbackFrom: primary, errorPrimary: msg }),
+        };
+      } catch (fallbackErr) {
+        const fbMsg = String((fallbackErr && fallbackErr.message) || fallbackErr || 'Error');
+        return {
+          statusCode: isTimeout ? 504 : ((err && err.status) || (fallbackErr && fallbackErr.status) || (is429 ? 429 : 502)),
+          headers: { ...corsHeaders, ...(is429 ? { 'Retry-After': '30' } : {}), ...(isTimeout ? { 'Retry-After': '15' } : {}) },
+          body: JSON.stringify({ error: 'Generation failed', details: msg, fallback: { tried: 'gemini', details: fbMsg } }),
+        };
+      }
+    }
+
+    const statusFromError = err && err.status;
+    let statusCode = isTimeout ? 504 : (is429 ? 429 : statusFromError || 502);
+    if (statusCode === 404) {
+      statusCode = 502;
+    }
+
+    return {
+      statusCode,
+      headers: { ...corsHeaders, ...(is429 ? { 'Retry-After': '30' } : {}), ...(isTimeout ? { 'Retry-After': '15' } : {}) },
+      body: JSON.stringify({ error: isTimeout ? 'Generation timed out' : 'Generation failed', details: msg, provider }),
+    };
+  }
 };


### PR DESCRIPTION
## Summary
- add per-IP rate limiting and optional bearer auth to the quiz generation function
- align origin handling and error responses with the feedback endpoint, including Retry-After headers
- document new environment variables for tuning rate limits and enforcing shared bearer tokens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d894f88ba083299a10b71fe3b30d2d