### PR TITLE
fix: allow eq-quiz fallback through csp

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -35,5 +35,6 @@ Hey future helper! This repo ships the [ez-quiz.app](https://ez-quiz.app) PWA pl
 - 2025-09-25 — Added client fallback to call `/.netlify/functions/generate-quiz` when `/api/generate` is missing so production keeps working even if Netlify redirects go missing.
 - 2025-09-26 — Hardened AI endpoint selection: client now cycles through `/.netlify/functions/generate-quiz`, `/api/generate`, and Netlify hosts (`https://ez-quiz.netlify.app/.netlify/functions/generate-quiz`, `https://eq-quiz.netlify.app/.netlify/functions/generate-quiz`); cache-busters bumped to v1.5.14 with SW cache v123 so the fix lands instantly; CSP updated to allow both Netlify fallback domains in `connect-src`; backend default model now `gemini-2.0-flash`.
 - 2025-09-27 — Removed unused legacy root HTML assets/screenshots and an unused helper stub in `settings.js`.
+- 2025-09-27 — Added the eq-quiz Netlify fallback domain to CSP connect-src so production fallback fetches succeed.
 
 — Codex (GPT-5), 2025-02-14

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,7 +35,7 @@
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     # Keep CSP minimal; update if adding external origins.
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://ez-quiz.netlify.app https://ezquiz.dev;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://ez-quiz.netlify.app https://eq-quiz.netlify.app https://ezquiz.dev;"
 
 [[headers]]
   for = "/index.html"


### PR DESCRIPTION
## Summary
- add eq-quiz Netlify fallback host to the CSP connect-src whitelist so the client can reach the backup function endpoint
- log the CSP fix in agents.md for the next maintainer

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db5a1894a48329821629e934f25038