### PR TITLE
ui(footer): a11y+responsive polish (stacked)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,7 +35,7 @@
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     # Keep CSP minimal; update if adding external origins.
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn.buymeacoffee.com; font-src 'self' data:; connect-src 'self' https://ez-quiz.netlify.app https://eq-quiz.netlify.app https://ezquiz.dev;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn.buymeacoffee.com; font-src 'self' data:; connect-src 'self' https://ez-quiz.netlify.app https://eq-quiz.netlify.app https://ezquiz.dev https://cdn.buymeacoffee.com https://app.netlify.com; frame-src 'self' https://app.netlify.com;"
 
 [[headers]]
   for = "/index.html"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-quiz-app",
-  "version": "1.5.0-beta.7",
+  "version": "1.5.0-beta.9",
   "private": true,
   "license": "MIT",
   "description": "Static PWA + Netlify Functions for EZ Quiz",

--- a/public/index.html
+++ b/public/index.html
@@ -228,7 +228,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
   <footer class="container" role="contentinfo">
     <nav aria-label="Footer">
       <div class="footer-links" role="list">
-        <a id="versionInfoBtn" href="#" aria-haspopup="dialog" aria-controls="releaseNotesModal" role="listitem">v3.3</a>
+        <a id="versionInfoBtn" href="#" aria-haspopup="dialog" aria-controls="releaseNotesModal" role="listitem">v1.5.0-beta.9</a>
         <span aria-hidden="true">•</span>
         <a id="changelogLink" href="#" data-modal="releaseNotesModal" role="listitem">Changelog</a>
         <span aria-hidden="true">•</span>

--- a/public/index.html
+++ b/public/index.html
@@ -237,7 +237,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
         <a id="termsLink" href="#" data-modal="termsModal" role="listitem">Terms</a>
       </div>
       <div class="support-cta" aria-label="Support">
-        <a id="bmcButton" href="https://www.buymeacoffee.com/seanyates78" target="_blank" rel="noopener" aria-label="Buy me a coffee">
+        <a id="bmcButton" href="https://www.buymeacoffee.com/seanyates78" target="_blank" rel="noopener noreferrer nofollow" aria-label="Buy me a coffee">
           <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="217" height="60" />
         </a>
       </div>

--- a/public/js/patches.js
+++ b/public/js/patches.js
@@ -108,6 +108,20 @@ function wireFooterModals(){
   }catch{}
 }
 
+function adjustFabReserve(){
+  try{
+    const root = document.documentElement;
+    const stack = document.getElementById('floatingActions');
+    let reservePx = 16;
+    if (stack && stack.offsetParent !== null) {
+      const rect = stack.getBoundingClientRect();
+      // Use height plus a small margin; clamp to sensible range
+      reservePx = Math.max(12, Math.min(160, Math.round(rect.height + 24)));
+    }
+    root.style.setProperty('--fab-reserve', reservePx + 'px');
+  }catch{}
+}
+
 document.addEventListener('DOMContentLoaded', ()=>{
   wireMirror();
   wireStartHint();
@@ -116,6 +130,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
   wireBrandSwap();
   wireSupportSwap();
   wireFooterModals();
+  adjustFabReserve();
+  window.addEventListener('resize', adjustFabReserve);
   // IE fallback: ensure the IE toggle at least shows/hides the mount
   try{
     const toggle = document.getElementById('toggleInteractiveEditor') || document.querySelector('[data-role="quiz-editor-toggle"]');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1185,6 +1185,7 @@ footer.container{
 /* Official support button container */
 .support-cta{ display:flex; justify-content:center; align-items:center; margin: 6px 0 18px 0; }
 .support-cta img{ display:block; height:44px; width:auto; }
+@media (max-width:420px){ .support-cta img{ height:36px } }
 /* Footer links row */
 .footer-links{ display:flex; justify-content:center; align-items:center; gap:10px; margin:8px 0; color:var(--muted); }
 .footer-links a{ text-decoration:none; font-weight:600; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1176,8 +1176,8 @@ footer.container{
   margin-top:auto;
   /* Keep some internal breathing room */
   padding-top:8px;
-  /* Reserve space so floating buttons never cover the footer */
-  padding-bottom:calc(12px + var(--fab-reserve, 112px) + env(safe-area-inset-bottom, 0px));
+  /* Reserve space so floating buttons never cover the footer (dynamic via --fab-reserve) */
+  padding-bottom:calc(12px + var(--fab-reserve, 16px) + env(safe-area-inset-bottom, 0px));
   margin-bottom:0;
   /* Avoid FAB overlap on the right on narrow screens */
   padding-right: var(--fab-right-pad, 0px);

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v123';
+const CACHE_NAME = 'ezquiz-cache-v124';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',


### PR DESCRIPTION
Small follow-up: add rel='noopener noreferrer nofollow' to BMC link and reduce CTA height on very small screens.