### PR TITLE
Prevent page drag while adjusting difficulty slider

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -755,6 +755,8 @@ body[data-theme="light"] .gen-toolbar .difficulty-stack:hover{
   display:block;
   cursor:pointer;
   -webkit-tap-highlight-color:transparent;
+  touch-action:pan-x;
+  -ms-touch-action:pan-x;
 }
 .difficulty-slider input[type="range"]::-webkit-slider-runnable-track{
   height:var(--track-height);


### PR DESCRIPTION
## Summary
- add touch-action constraints to the difficulty slider range input so dragging it no longer scrolls the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f32c04baa88329810a898df8de2fab