### PR TITLE
Centralize beta gating logic for results explain controls

### DIFF
--- a/public/js/beta.mjs
+++ b/public/js/beta.mjs
@@ -1,0 +1,16 @@
+export function isBetaEnabled(settings) {
+  if (settings && settings.betaEnabled) return true;
+  if (typeof document === 'undefined') return false;
+  const body = document.body;
+  if (!body) return false;
+  try {
+    if (typeof body.hasAttribute === 'function' && body.hasAttribute('data-beta')) {
+      return true;
+    }
+  } catch {}
+  const dataset = body.dataset;
+  if (dataset && ('beta' in dataset)) {
+    return true;
+  }
+  return false;
+}

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1,4 +1,5 @@
 import { S } from './state.js';
+import { isBetaEnabled } from './beta.mjs';
 import { $, byQSA, clamp, formatDuration, escapeHTML, indexesToLetters, arraysEqual, formatTopicLabel, mmSsToMs, showUpdateBannerIfReady, bindOnce } from './utils.js';
 
 // Retake scope constants
@@ -188,7 +189,7 @@ export function renderResults(){
   const indexMap = (Array.isArray(S.quiz.indexMap) && S.quiz.indexMap.length)
     ? S.quiz.indexMap
     : S.quiz.questions.map((_,i)=>i);
-  const isBeta = !!((S.settings && S.settings.betaEnabled) || (typeof document !== 'undefined' && document.body && document.body.dataset && document.body.dataset.beta === 'true'));
+  const isBeta = isBetaEnabled(S.settings);
   // Prefer persistent originalAnswers when available; fallback to mapping current run
   let answersFull;
   if (Array.isArray(S.quiz.originalAnswers) && S.quiz.originalAnswers.length === baseQs.length) {
@@ -245,7 +246,7 @@ export function renderResults(){
   // Sync retake controls UI when results are shown/updated
   try{ updateRetakeUI(); }catch{}
   // Wire Explain delegation once (beta only)
-  try{ if(S.settings && S.settings.betaEnabled){ wireExplainDelegation(); } }catch{}
+  try{ if(isBetaEnabled(S.settings)){ wireExplainDelegation(); } }catch{}
   // Update chip after we know full correctness
   if(chip){
     const labelText = `${correctCountFull}/${baseQs.length}`;
@@ -326,7 +327,7 @@ function wireExplainDelegation(){
     const key = `${hash}|${idx}`;
     box.hidden = false; box.textContent = 'Generating explanation…';
     // In beta, teaser only — no network call
-    if ((S.settings && S.settings.betaEnabled) || (typeof document !== 'undefined' && document.body && document.body.dataset && document.body.dataset.beta === 'true')) {
+    if (isBetaEnabled(S.settings)) {
       const teaser = [
         '┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓',
         '┃          FEATURE COMING SOON          ┃',
@@ -433,7 +434,7 @@ function buildCorrectAnswerDetail(q){
 }
 
 function renderMTResult(origIdx, q, a){
-  const isBeta = !!(S.settings && S.settings.betaEnabled);
+  const isBeta = isBetaEnabled(S.settings);
   // Build map of correct right indexes by left index
   const correctMap = new Array(q.left.length).fill(-1);
   (Array.isArray(q.pairs)?q.pairs:[]).forEach(([li,ri])=>{ correctMap[li]=ri; });

--- a/public/styles.css
+++ b/public/styles.css
@@ -755,6 +755,8 @@ body[data-theme="light"] .gen-toolbar .difficulty-stack:hover{
   display:block;
   cursor:pointer;
   -webkit-tap-highlight-color:transparent;
+  touch-action:pan-x;
+  -ms-touch-action:pan-x;
 }
 .difficulty-slider input[type="range"]::-webkit-slider-runnable-track{
   height:var(--track-height);

--- a/public/styles.css
+++ b/public/styles.css
@@ -699,6 +699,7 @@ body[data-theme="light"] .number-wrap:focus-within{ background:var(--panel); }
   min-height:var(--toolbar-height, 40px);
   height:var(--toolbar-height, 40px);
   transition:border-color .18s ease, background .18s ease, box-shadow .18s ease;
+  overscroll-behavior:contain;
 }
 body[data-theme="light"] .difficulty-stack{ background:var(--panel); }
 .difficulty-stack:hover{
@@ -743,6 +744,7 @@ body[data-theme="light"] .gen-toolbar .difficulty-stack:hover{
   position:relative;
   width:100%;
   padding:0;
+  touch-action:none;
 }
 .difficulty-slider input[type="range"]{
   width:100%;
@@ -755,8 +757,8 @@ body[data-theme="light"] .gen-toolbar .difficulty-stack:hover{
   display:block;
   cursor:pointer;
   -webkit-tap-highlight-color:transparent;
-  touch-action:pan-x;
-  -ms-touch-action:pan-x;
+  touch-action:none;
+  -ms-touch-action:none;
 }
 .difficulty-slider input[type="range"]::-webkit-slider-runnable-track{
   height:var(--track-height);

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * page for navigation requests when offline.
  */
 
-const CACHE_NAME = 'ezquiz-cache-v124';
+const CACHE_NAME = 'ezquiz-cache-v125';
 const RELATIVE_URLS = [
   'index.html',
   'js/state.js',
@@ -20,6 +20,7 @@ const RELATIVE_URLS = [
   'js/modals.js',
   'js/generator.js?v=1.5.14',
   'js/quiz.js',
+  'js/beta.mjs',
   // Versioned assets to avoid stale caches on first offline load
   'styles.css?v=1.5.14',
   'js/main.js?v=1.5.14',

--- a/tests/beta-gating.test.js
+++ b/tests/beta-gating.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+describe('beta gating helper', () => {
+  afterEach(() => {
+    delete global.document;
+  });
+
+  test('returns true when settings flag is enabled', async () => {
+    const { isBetaEnabled } = await import('../public/js/beta.mjs');
+    expect(isBetaEnabled({ betaEnabled: true })).toBe(true);
+  });
+
+  test('returns true when data-beta attribute is present', async () => {
+    const { isBetaEnabled } = await import('../public/js/beta.mjs');
+    global.document = { body: { hasAttribute: () => false, dataset: { beta: '' } } };
+    expect(isBetaEnabled({ betaEnabled: false })).toBe(true);
+  });
+
+  test('returns false when beta is disabled everywhere', async () => {
+    const { isBetaEnabled } = await import('../public/js/beta.mjs');
+    expect(isBetaEnabled({ betaEnabled: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared beta detection helper used by the results renderer and explain wiring
- treat the presence of the body[data-beta] attribute as enabling beta, alongside the settings flag
- add unit coverage ensuring the helper honors both the settings toggle and body attribute

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f32c04baa88329810a898df8de2fab