### PR TITLE
Harden media import pipeline

### DIFF
--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -2,6 +2,7 @@ import { S } from './state.js';
 import { $, byQSA, mmSsToMs } from './utils.js';
 import { parseEditorInput } from './parser.js';
 import { generateWithAI } from './api.js?v=1.5.17';
+import { createImportHandler } from './importer.js?v=1.5.17';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';
@@ -82,21 +83,39 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   
   // --- Media Import (beta) ---
   function isBeta(){ try{ return document.body?.dataset?.beta === 'true' || !!S.settings?.betaEnabled; }catch{ return false; } }
-  function setHint(msg){ try{ const hint=document.getElementById('regenHint'); if(hint){ hint.textContent = msg; hint.hidden = false; } }catch{} }
-  function clearHint(){ try{ const hint=document.getElementById('regenHint'); if(hint){ hint.hidden = true; } }catch{} }
-  async function postIngest(payload){
+  function setHint(msg){
+    try{
+      const hint = document.getElementById('regenHint');
+      if(hint){
+        hint.textContent = msg;
+        hint.hidden = !msg;
+      }
+    }catch{}
+  }
+  function clearHint(){
+    try{
+      const hint = document.getElementById('regenHint');
+      if(hint){
+        hint.textContent = '';
+        hint.hidden = true;
+      }
+    }catch{}
+  }
+  async function postIngest(payload, { signal } = {}){
     const endpoint = '/.netlify/functions/ingest-media';
     try{
       const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-ezq-beta': '1' },
         body: JSON.stringify(payload),
+        signal,
       });
       const ct = res.headers.get('content-type')||'';
       const isJson = ct.includes('application/json');
       const data = isJson ? await res.json() : await res.text();
       return { ok: res.ok, status: res.status, data };
     }catch(err){
+      if(err && err.name === 'AbortError') throw err;
       return { ok: false, status: 0, data: { error: String(err&&err.message||err||'Network error') } };
     }
   }
@@ -116,38 +135,23 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
       reader.readAsDataURL(file);
     });
   }
-  async function handleMediaFile(file){
-    if(!file) return;
-    const type = String(file.type||'');
-    if(!(type.startsWith('image/') || type === 'application/pdf')){ setHint('Unsupported file. Choose a PDF or image.'); return; }
-    setHint('Importing…');
-    try{
-      const { base64 } = await toBase64(file);
-      const resp = await postIngest({ name:file.name||'', type, size:file.size||0, data: base64 });
-      if(resp.ok && resp.data && resp.data.text){
-        // If backend returns extracted text, fill editor + parse
-        const text = String(resp.data.text||'');
-        setEditorText(text);
-        try{ setMirrorVisible(true); }catch{}
-        runParseFlow(text, file.name||'Imported', '');
-        setHint('Imported text added to editor.');
-      } else {
-        // Friendly fallback messages
-        if(resp.status === 404){ setHint('Media import not enabled on this site.'); }
-        else if(resp.status === 501){ setHint('Media ingest is not enabled yet (beta stub).'); }
-        else if(resp.status === 403){ setHint('Media import is beta-only. Enable beta in Settings or visit /beta.'); }
-        else { setHint('Media import unavailable.'); }
-      }
-    }catch{
-      setHint('Import failed.');
-    }
-  }
+  const { handleImportFile } = createImportHandler({
+    importBtn,
+    importFile,
+    setHint,
+    clearHint,
+    setEditorText,
+    setMirrorVisible,
+    runParseFlow,
+    postIngest,
+    toBase64,
+  });
   importBtn?.addEventListener('click', ()=>{ if(!isBeta()) return; importFile?.click(); });
-  importFile?.addEventListener('change', ()=>{ if(!isBeta()) return; const f=importFile.files&&importFile.files[0]; if(!f) return; handleMediaFile(f); importFile.value=''; });
+  importFile?.addEventListener('change', ()=>{ if(!isBeta()) return; const f=importFile.files&&importFile.files[0]; if(!f) return; handleImportFile(f).catch(()=>{}); });
   // Drag-drop on toolbar (beta)
   const onDragOver = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.add('drag-on'); };
   const clearDrag = (el)=>{ el.classList.remove('drag-on'); };
-  const onDrop = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.remove('drag-on'); const dt=e.dataTransfer; if(!dt||!dt.files||!dt.files.length) return; handleMediaFile(dt.files[0]); };
+  const onDrop = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.remove('drag-on'); const dt=e.dataTransfer; if(!dt||!dt.files||!dt.files.length) return; handleImportFile(dt.files[0]).catch(()=>{}); };
   topicAffix?.addEventListener('dragover', (e)=> onDragOver(e, topicAffix));
   topicAffix?.addEventListener('dragleave', ()=> clearDrag(topicAffix));
   topicAffix?.addEventListener('drop', (e)=> onDrop(e, topicAffix));

--- a/public/js/importer.js
+++ b/public/js/importer.js
@@ -1,0 +1,178 @@
+export class ImportController {
+  constructor() {
+    this._token = 0;
+    this._controller = null;
+  }
+
+  start() {
+    if (this._controller) {
+      try {
+        this._controller.abort();
+      } catch {}
+    }
+    this._controller = new AbortController();
+    this._token += 1;
+    const token = this._token;
+    return { token, signal: this._controller.signal };
+  }
+
+  abort() {
+    if (this._controller) {
+      try { this._controller.abort(); } catch {}
+    }
+  }
+
+  isCurrent(token) {
+    if (token !== this._token) return false;
+    const signal = this._controller?.signal;
+    return !(signal && signal.aborted);
+  }
+
+  finish(token) {
+    if (token === this._token) {
+      this._controller = null;
+    }
+  }
+}
+
+function matchBytes(bytes, signature) {
+  if (bytes.length < signature.length) return false;
+  for (let i = 0; i < signature.length; i += 1) {
+    if (bytes[i] !== signature[i]) return false;
+  }
+  return true;
+}
+
+export async function sniffFileKind(file, { signal } = {}) {
+  if (!file || typeof file.slice !== 'function') {
+    return { kind: 'unknown' };
+  }
+
+  if (signal?.aborted) {
+    throw new DOMException('Operation aborted', 'AbortError');
+  }
+
+  const head = file.slice(0, 12);
+  const buffer = await head.arrayBuffer();
+
+  if (signal?.aborted) {
+    throw new DOMException('Operation aborted', 'AbortError');
+  }
+
+  const bytes = new Uint8Array(buffer);
+
+  if (matchBytes(bytes, [0x25, 0x50, 0x44, 0x46])) {
+    return { kind: 'pdf' };
+  }
+
+  if (matchBytes(bytes, [0xff, 0xd8])) {
+    return { kind: 'jpeg' };
+  }
+
+  if (matchBytes(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return { kind: 'png' };
+  }
+
+  const header = String.fromCharCode(...bytes.slice(0, 6));
+  if (header === 'GIF87a' || header === 'GIF89a') {
+    return { kind: 'gif' };
+  }
+
+  return { kind: 'unknown' };
+}
+
+export function createImportHandler({
+  importBtn,
+  importFile,
+  setHint,
+  clearHint,
+  setEditorText,
+  setMirrorVisible,
+  runParseFlow,
+  postIngest,
+  toBase64,
+  sniffFileKind: sniff = sniffFileKind,
+} = {}) {
+  const controller = new ImportController();
+
+  function setBusy(on) {
+    if (importBtn) importBtn.disabled = !!on;
+  }
+
+  async function handleImportFile(file) {
+    if (!file) {
+      if (importFile) importFile.value = '';
+      return;
+    }
+
+    const { token, signal } = controller.start();
+    setBusy(true);
+    clearHint?.();
+
+    try {
+      const kind = await sniff(file, { signal });
+      if (!controller.isCurrent(token)) return;
+
+      if (!kind || kind.kind === 'unknown') {
+        setHint?.('Unsupported file. Choose a PDF or image.');
+        return;
+      }
+
+      setHint?.('Importing…');
+
+      const { base64 } = await toBase64(file);
+      if (!controller.isCurrent(token)) return;
+
+      const response = await postIngest(
+        {
+          name: file.name || '',
+          type: file.type || '',
+          size: file.size || 0,
+          data: base64,
+        },
+        { signal },
+      );
+
+      if (!controller.isCurrent(token)) return;
+
+      if (response && response.ok && response.data && response.data.text) {
+        const text = String(response.data.text || '');
+        setEditorText?.(text);
+        setMirrorVisible?.(true);
+        runParseFlow?.(text, file.name || 'Imported', '');
+        setHint?.('Imported text added to editor.');
+        return;
+      }
+
+      if (response) {
+        if (response.status === 404) {
+          setHint?.('Media import not enabled on this site.');
+        } else if (response.status === 501) {
+          setHint?.('Media ingest is not enabled yet (beta stub).');
+        } else if (response.status === 403) {
+          setHint?.('Media import is beta-only. Enable beta in Settings or visit /beta.');
+        } else {
+          setHint?.('Media import unavailable.');
+        }
+        return;
+      }
+
+      setHint?.('Media import unavailable.');
+    } catch (err) {
+      if (!controller.isCurrent(token)) return;
+      if (err && err.name === 'AbortError') {
+        clearHint?.();
+      } else {
+        setHint?.('Import failed.');
+      }
+    } finally {
+      if (controller.isCurrent(token)) {
+        setBusy(false);
+        controller.finish(token);
+      }
+      if (importFile) importFile.value = '';
+    }
+  }
+
+  return { controller, handleImportFile };
+}

--- a/tests/importer.test.js
+++ b/tests/importer.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const vm = require('node:vm');
+
+const bytes = (...values) => Uint8Array.from(values);
+
+function createFile(data, { name = 'file.bin', type = 'application/octet-stream' } = {}) {
+  return new File([data], name, { type });
+}
+
+describe('Import pipeline helpers', () => {
+  let importer;
+
+  beforeAll(async () => {
+    const code = await fs.readFile(path.resolve(__dirname, '../public/js/importer.js'), 'utf8');
+    const context = vm.createContext({
+      console,
+      AbortController,
+      DOMException,
+      File,
+      Blob,
+      setTimeout,
+      clearTimeout,
+    });
+    context.globalThis = context;
+    const module = new vm.SourceTextModule(code, { context });
+    await module.link(() => { throw new Error('Unexpected import in importer.js'); });
+    await module.evaluate();
+    importer = module.namespace;
+  });
+
+  test('sniffFileKind detects common media headers', async () => {
+    const pdf = await importer.sniffFileKind(createFile(bytes(0x25, 0x50, 0x44, 0x46, 0x2d), { type: 'application/pdf' }));
+    expect(pdf.kind).toBe('pdf');
+
+    const jpeg = await importer.sniffFileKind(createFile(bytes(0xff, 0xd8, 0xff, 0xdb), { type: 'image/jpeg' }));
+    expect(jpeg.kind).toBe('jpeg');
+
+    const png = await importer.sniffFileKind(createFile(bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a), { type: 'image/png' }));
+    expect(png.kind).toBe('png');
+
+    const gif = await importer.sniffFileKind(createFile(bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61), { type: 'image/gif' }));
+    expect(gif.kind).toBe('gif');
+
+    const unknown = await importer.sniffFileKind(createFile(bytes(0x00, 0x11, 0x22, 0x33)));
+    expect(unknown.kind).toBe('unknown');
+  });
+
+  test('ImportController manages sequential tokens and aborts previous signal', () => {
+    const controller = new importer.ImportController();
+    const first = controller.start();
+    expect(first.token).toBe(1);
+    expect(first.signal.aborted).toBe(false);
+
+    const second = controller.start();
+    expect(second.token).toBe(2);
+    expect(first.signal.aborted).toBe(true);
+    expect(controller.isCurrent(first.token)).toBe(false);
+    expect(controller.isCurrent(second.token)).toBe(true);
+
+    controller.abort();
+    expect(controller.isCurrent(second.token)).toBe(false);
+  });
+
+  test('handleImportFile only applies results from the most recent request', async () => {
+    const importBtn = { disabled: false };
+    const importFile = { value: 'preset' };
+    const setHint = jest.fn();
+    const clearHint = jest.fn();
+    const setEditorText = jest.fn();
+    const setMirrorVisible = jest.fn();
+    const runParseFlow = jest.fn();
+
+    const sniff = jest.fn(async () => ({ kind: 'pdf' }));
+    const toBase64 = jest.fn(async () => ({ base64: 'ZmFrZQ==' }));
+    const postIngest = jest.fn((payload, { signal } = {}) => {
+      if (payload.name === 'first.pdf') {
+        return new Promise((resolve, reject) => {
+          if (signal?.aborted) {
+            reject(new DOMException('Aborted', 'AbortError'));
+            return;
+          }
+          const onAbort = () => {
+            signal.removeEventListener('abort', onAbort);
+            reject(new DOMException('Aborted', 'AbortError'));
+          };
+          signal?.addEventListener('abort', onAbort);
+        });
+      }
+
+      return Promise.resolve({ ok: true, status: 200, data: { text: 'second import' } });
+    });
+
+    const { handleImportFile } = importer.createImportHandler({
+      importBtn,
+      importFile,
+      setHint,
+      clearHint,
+      setEditorText,
+      setMirrorVisible,
+      runParseFlow,
+      postIngest,
+      toBase64,
+      sniffFileKind: sniff,
+    });
+
+    const firstFile = createFile(bytes(0x25, 0x50, 0x44, 0x46), { name: 'first.pdf', type: 'application/pdf' });
+    const secondFile = createFile(bytes(0x25, 0x50, 0x44, 0x46), { name: 'second.pdf', type: 'application/pdf' });
+
+    const firstPromise = handleImportFile(firstFile);
+    const secondPromise = handleImportFile(secondFile);
+
+    await Promise.allSettled([firstPromise, secondPromise]);
+
+    expect(setEditorText).toHaveBeenCalledTimes(1);
+    expect(setEditorText).toHaveBeenCalledWith('second import');
+    expect(runParseFlow).toHaveBeenCalledTimes(1);
+    expect(runParseFlow.mock.calls[0][0]).toBe('second import');
+    expect(importBtn.disabled).toBe(false);
+    expect(importFile.value).toBe('');
+    expect(clearHint).toHaveBeenCalled();
+  });
+
+  test('handleImportFile resets UI on error paths', async () => {
+    const importBtn = { disabled: false };
+    const importFile = { value: 'pending' };
+    const setHint = jest.fn();
+    const clearHint = jest.fn();
+
+    const { handleImportFile } = importer.createImportHandler({
+      importBtn,
+      importFile,
+      setHint,
+      clearHint,
+      setEditorText: jest.fn(),
+      setMirrorVisible: jest.fn(),
+      runParseFlow: jest.fn(),
+      postIngest: jest.fn(async () => { throw new Error('boom'); }),
+      toBase64: jest.fn(async () => ({ base64: 'data' })),
+      sniffFileKind: jest.fn(async () => ({ kind: 'pdf' })),
+    });
+
+    const file = createFile(bytes(0x25, 0x50, 0x44, 0x46), { name: 'error.pdf', type: 'application/pdf' });
+    await handleImportFile(file);
+
+    expect(importBtn.disabled).toBe(false);
+    expect(importFile.value).toBe('');
+    expect(setHint).toHaveBeenCalledWith('Import failed.');
+  });
+});


### PR DESCRIPTION
## Summary
- Implement PR-001: Import Pipeline Hardening by introducing a shared import controller that gates UI updates, disables the button while pending, and resets the file input on exit paths.
- Add magic-byte validation and centralized hint handling so only the latest import updates the editor or status messaging.
- Cover the new importer utilities with unit tests to exercise sniffing, controller sequencing, and UI reset behavior.

## Screenshots
- Not applicable (no visual regressions to capture)

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f45000a3bc8329ba3b1ffe7a3a840c