### PR TITLE
Harden beta media import flow

### DIFF
--- a/public/js/file-type-validation.js
+++ b/public/js/file-type-validation.js
@@ -1,0 +1,31 @@
+const SUPPORTED_KINDS = new Set(['pdf', 'png', 'jpeg', 'gif']);
+
+export async function sniffFileKind(file) {
+  try {
+    const head = new Uint8Array(await file.slice(0, 8).arrayBuffer());
+
+    // PDF: "%PDF"
+    if (head[0] === 0x25 && head[1] === 0x50 && head[2] === 0x44 && head[3] === 0x46) {
+      return 'pdf';
+    }
+    // PNG: 89 50 4E 47
+    if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4E && head[3] === 0x47) {
+      return 'png';
+    }
+    // JPEG: FF D8 FF (next marker varies)
+    if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) {
+      return 'jpeg';
+    }
+    // GIF87a / GIF89a: 47 49 46 38
+    if (head[0] === 0x47 && head[1] === 0x49 && head[2] === 0x46 && head[3] === 0x38) {
+      return 'gif';
+    }
+  } catch {
+    // Ignore read errors and fall through to unknown
+  }
+  return 'unknown';
+}
+
+export function isSupportedImportKind(kind) {
+  return SUPPORTED_KINDS.has(kind);
+}

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -2,6 +2,8 @@ import { S } from './state.js';
 import { $, byQSA, mmSsToMs } from './utils.js';
 import { parseEditorInput } from './parser.js';
 import { generateWithAI } from './api.js?v=1.5.17';
+import { ImportController } from './import-controller.js';
+import { sniffFileKind, isSupportedImportKind } from './file-type-validation.js';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';
@@ -46,6 +48,13 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   const countDownBtn = document.querySelector('[data-step="down"]');
   const importBtn = $('importBtn');
   const importFile = $('importFile');
+  const importCtl = new ImportController();
+  const MIME_BY_KIND = {
+    pdf: 'application/pdf',
+    png: 'image/png',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+  };
   const toolbar = document.querySelector('.gen-toolbar');
   const topicAffix = document.querySelector('.topic-affix');
   const editor = $('editor');
@@ -84,26 +93,49 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   function isBeta(){ try{ return document.body?.dataset?.beta === 'true' || !!S.settings?.betaEnabled; }catch{ return false; } }
   function setHint(msg){ try{ const hint=document.getElementById('regenHint'); if(hint){ hint.textContent = msg; hint.hidden = false; } }catch{} }
   function clearHint(){ try{ const hint=document.getElementById('regenHint'); if(hint){ hint.hidden = true; } }catch{} }
-  async function postIngest(payload){
+  async function postIngest(payload, { signal } = {}){
     const endpoint = '/.netlify/functions/ingest-media';
     try{
       const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-ezq-beta': '1' },
         body: JSON.stringify(payload),
+        signal,
       });
       const ct = res.headers.get('content-type')||'';
       const isJson = ct.includes('application/json');
       const data = isJson ? await res.json() : await res.text();
       return { ok: res.ok, status: res.status, data };
     }catch(err){
+      if(err && err.name === 'AbortError'){ throw err; }
       return { ok: false, status: 0, data: { error: String(err&&err.message||err||'Network error') } };
     }
   }
-  function toBase64(file){
+  function toBase64(file, { signal } = {}){
     return new Promise((resolve,reject)=>{
       const reader = new FileReader();
+      let settled = false;
+      const cleanup = ()=>{
+        settled = true;
+        reader.onload = null;
+        reader.onerror = null;
+        if(signal){
+          try{ signal.removeEventListener('abort', abort); }catch{}
+        }
+      };
+      const abort = ()=>{
+        if(settled) return;
+        cleanup();
+        try{ reader.abort(); }catch{}
+        reject(new DOMException('Aborted','AbortError'));
+      };
+      if(signal){
+        if(signal.aborted){ return abort(); }
+        signal.addEventListener('abort', abort, { once: true });
+      }
       reader.onload = ()=>{
+        if(settled) return;
+        cleanup();
         try{
           const url = String(reader.result||'');
           const comma = url.indexOf(',');
@@ -112,42 +144,84 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
           resolve({ base64: b64, meta });
         }catch(e){ reject(e); }
       };
-      reader.onerror = ()=> reject(reader.error||new Error('Read failed'));
+      reader.onerror = ()=>{
+        if(settled) return;
+        cleanup();
+        reject(reader.error||new Error('Read failed'));
+      };
       reader.readAsDataURL(file);
     });
   }
-  async function handleMediaFile(file){
+  async function handleImportFile(file){
     if(!file) return;
-    const type = String(file.type||'');
-    if(!(type.startsWith('image/') || type === 'application/pdf')){ setHint('Unsupported file. Choose a PDF or image.'); return; }
-    setHint('Importing…');
+    const { token, signal } = importCtl.start();
     try{
-      const { base64 } = await toBase64(file);
-      const resp = await postIngest({ name:file.name||'', type, size:file.size||0, data: base64 });
-      if(resp.ok && resp.data && resp.data.text){
-        // If backend returns extracted text, fill editor + parse
+      importBtn?.setAttribute('disabled', 'true');
+      clearHint();
+      if(importCtl.isCurrent(token)) setHint('Importing…');
+
+      const kind = await sniffFileKind(file);
+      if(!importCtl.isCurrent(token)) return;
+      if(!isSupportedImportKind(kind)){
+        if(importCtl.isCurrent(token)) setHint('Unsupported file. Choose a PDF or image.');
+        return;
+      }
+
+      const { base64 } = await toBase64(file, { signal });
+      if(!importCtl.isCurrent(token)) return;
+
+      const resp = await postIngest({
+        name: file.name||'',
+        type: file.type || MIME_BY_KIND[kind] || '',
+        size: file.size||0,
+        data: base64,
+        kind,
+      }, { signal });
+      if(!importCtl.isCurrent(token)) return;
+
+      if(resp && resp.ok && resp.data && resp.data.text){
         const text = String(resp.data.text||'');
-        setEditorText(text);
-        try{ setMirrorVisible(true); }catch{}
-        runParseFlow(text, file.name||'Imported', '');
-        setHint('Imported text added to editor.');
-      } else {
-        // Friendly fallback messages
-        if(resp.status === 404){ setHint('Media import not enabled on this site.'); }
-        else if(resp.status === 501){ setHint('Media ingest is not enabled yet (beta stub).'); }
-        else if(resp.status === 403){ setHint('Media import is beta-only. Enable beta in Settings or visit /beta.'); }
+        if(importCtl.isCurrent(token)){
+          setEditorText(text);
+          try{ setMirrorVisible(true); }catch{}
+          try{
+            runParseFlow(text, file.name||'Imported', '');
+            setHint('Imported text added to editor.');
+          }catch(e){
+            setHint(`Parse error: ${e && e.message ? e.message : 'Unknown error'}`);
+          }
+        }
+      } else if(importCtl.isCurrent(token)){
+        if(resp && resp.status === 404){ setHint('Media import not enabled on this site.'); }
+        else if(resp && resp.status === 501){ setHint('Media ingest is not enabled yet (beta stub).'); }
+        else if(resp && resp.status === 403){ setHint('Media import is beta-only. Enable beta in Settings or visit /beta.'); }
+        else if(resp && resp.data && resp.data.error){ setHint(String(resp.data.error)); }
         else { setHint('Media import unavailable.'); }
       }
-    }catch{
-      setHint('Import failed.');
+    }catch(err){
+      if(err && err.name === 'AbortError'){ return; }
+      if(importCtl.isCurrent(token)){
+        setHint(`Import error: ${err && err.message ? err.message : 'Unknown error'}`);
+      }
+    }finally{
+      importCtl.finish(token);
+      if(importCtl.isCurrent(token)){
+        importBtn?.removeAttribute('disabled');
+      }
+      if(importFile) importFile.value='';
     }
   }
   importBtn?.addEventListener('click', ()=>{ if(!isBeta()) return; importFile?.click(); });
-  importFile?.addEventListener('change', ()=>{ if(!isBeta()) return; const f=importFile.files&&importFile.files[0]; if(!f) return; handleMediaFile(f); importFile.value=''; });
+  importFile?.addEventListener('change', async ()=>{
+    if(!isBeta()) return;
+    const f = importFile?.files && importFile.files[0];
+    if(!f) return;
+    await handleImportFile(f);
+  });
   // Drag-drop on toolbar (beta)
   const onDragOver = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.add('drag-on'); };
   const clearDrag = (el)=>{ el.classList.remove('drag-on'); };
-  const onDrop = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.remove('drag-on'); const dt=e.dataTransfer; if(!dt||!dt.files||!dt.files.length) return; handleMediaFile(dt.files[0]); };
+  const onDrop = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.remove('drag-on'); const dt=e.dataTransfer; if(!dt||!dt.files||!dt.files.length) return; handleImportFile(dt.files[0]); };
   topicAffix?.addEventListener('dragover', (e)=> onDragOver(e, topicAffix));
   topicAffix?.addEventListener('dragleave', ()=> clearDrag(topicAffix));
   topicAffix?.addEventListener('drop', (e)=> onDrop(e, topicAffix));

--- a/public/js/import-controller.js
+++ b/public/js/import-controller.js
@@ -1,0 +1,43 @@
+export class ImportController {
+  constructor() {
+    this.currentToken = 0;
+    this.abortController = null;
+    this.pending = false;
+  }
+
+  start() {
+    this.currentToken += 1;
+    const token = this.currentToken;
+    if (this.abortController) {
+      try {
+        this.abortController.abort();
+      } catch {
+        // ignore abort errors from previous controller
+      }
+    }
+    this.abortController = new AbortController();
+    this.pending = true;
+    return { token, signal: this.abortController.signal };
+  }
+
+  isCurrent(token) {
+    return token === this.currentToken;
+  }
+
+  finish(token) {
+    if (this.isCurrent(token)) {
+      this.pending = false;
+    }
+  }
+
+  cancel() {
+    if (this.abortController) {
+      try {
+        this.abortController.abort();
+      } catch {
+        // ignore abort errors from current controller
+      }
+    }
+    this.pending = false;
+  }
+}

--- a/tests/file-type-validation.test.js
+++ b/tests/file-type-validation.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { loadBrowserModule } = require('./utils');
+
+describe('file type validation', () => {
+  let sniffFileKind;
+  let isSupportedImportKind;
+
+  beforeAll(() => {
+    ({ sniffFileKind, isSupportedImportKind } = loadBrowserModule('public/js/file-type-validation.js', ['sniffFileKind', 'isSupportedImportKind']));
+  });
+
+  const fromHex = (hex) => {
+    const pairs = hex.match(/.{1,2}/g) || [];
+    return Uint8Array.from(pairs.map((pair) => parseInt(pair, 16)));
+  };
+
+  const makeBlob = (hex) => new Blob([fromHex(hex)]);
+
+  test('detects pdf headers', async () => {
+    const blob = makeBlob('255044462d312e350a00'); // %PDF-1.5\n
+    await expect(sniffFileKind(blob)).resolves.toBe('pdf');
+  });
+
+  test('detects png headers', async () => {
+    const blob = makeBlob('89504e470d0a1a0a00');
+    await expect(sniffFileKind(blob)).resolves.toBe('png');
+  });
+
+  test('detects jpeg headers', async () => {
+    const blob = makeBlob('ffd8ffe000104a46494600');
+    await expect(sniffFileKind(blob)).resolves.toBe('jpeg');
+  });
+
+  test('detects gif headers', async () => {
+    const blob = makeBlob('47494638396126002600');
+    await expect(sniffFileKind(blob)).resolves.toBe('gif');
+  });
+
+  test('returns unknown for unsupported bytes', async () => {
+    const blob = makeBlob('0001020304050607');
+    await expect(sniffFileKind(blob)).resolves.toBe('unknown');
+  });
+
+  test('isSupportedImportKind flags supported values', () => {
+    expect(isSupportedImportKind('pdf')).toBe(true);
+    expect(isSupportedImportKind('png')).toBe(true);
+    expect(isSupportedImportKind('jpeg')).toBe(true);
+    expect(isSupportedImportKind('gif')).toBe(true);
+    expect(isSupportedImportKind('bmp')).toBe(false);
+  });
+});

--- a/tests/import-controller.test.js
+++ b/tests/import-controller.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { loadBrowserModule } = require('./utils');
+
+describe('ImportController', () => {
+  let ImportController;
+
+  beforeAll(() => {
+    ({ ImportController } = loadBrowserModule('public/js/import-controller.js', ['ImportController']));
+  });
+
+  test('start increments token and aborts previous controllers', () => {
+    const ctl = new ImportController();
+    const first = ctl.start();
+    expect(first.token).toBe(1);
+
+    let aborted = false;
+    first.signal.addEventListener('abort', () => { aborted = true; });
+
+    const second = ctl.start();
+    expect(second.token).toBe(2);
+    expect(aborted).toBe(true);
+    expect(ctl.isCurrent(second.token)).toBe(true);
+    expect(ctl.isCurrent(first.token)).toBe(false);
+  });
+
+  test('finish only clears pending for the current token', () => {
+    const ctl = new ImportController();
+    const first = ctl.start();
+    const second = ctl.start();
+
+    ctl.finish(first.token);
+    expect(ctl.pending).toBe(true);
+
+    ctl.finish(second.token);
+    expect(ctl.pending).toBe(false);
+  });
+
+  test('cancel aborts the current signal and resets pending state', () => {
+    const ctl = new ImportController();
+    const { signal } = ctl.start();
+
+    let aborted = false;
+    signal.addEventListener('abort', () => { aborted = true; });
+
+    ctl.cancel();
+    expect(aborted).toBe(true);
+    expect(ctl.pending).toBe(false);
+  });
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -24,6 +24,20 @@ function readFile(relPath) {
   return fs.readFileSync(resolve(relPath), 'utf8');
 }
 
+function loadBrowserModule(relPath, namedExports) {
+  if (!Array.isArray(namedExports) || namedExports.length === 0) {
+    throw new Error('namedExports must be a non-empty array');
+  }
+  const absPath = resolve(relPath);
+  const source = readFile(relPath)
+    .replace(/export\s+class\s+/g, 'class ')
+    .replace(/export\s+async\s+function\s+/g, 'async function ')
+    .replace(/export\s+function\s+/g, 'function ');
+  // Evaluate in the current context so browser globals like Blob remain available.
+  const factory = new Function(`${source}\nreturn { ${namedExports.join(', ')} };\n//# sourceURL=${absPath}`);
+  return factory();
+}
+
 async function loadDocument(relPath) {
   const html = readFile(relPath);
   const { JSDOM } = await getJsdomModule();
@@ -33,5 +47,6 @@ async function loadDocument(relPath) {
 
 module.exports = {
   readFile,
+  loadBrowserModule,
   loadDocument,
 };


### PR DESCRIPTION
## Summary
- gate beta media imports through an ImportController so only the latest run updates the editor and controls
- validate PDFs and images via magic-byte sniffing before uploading and reset the import UI on every path
- add unit tests for the ImportController, file-type sniffing, and a browser module loader helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4800cb88883299e4c2cee6a5b335c