### PR TITLE
PR-002: Input Validation & Listener Lifecycle

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  moduleNameMapper: {}
+  moduleNameMapper: {},
+  testPathIgnorePatterns: ['/node_modules/', '/PR-2-Files/'],
 };

--- a/public/js/drag-drop.js
+++ b/public/js/drag-drop.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Small utility to attach drag/drop handlers and support tidy teardown.
+// Usage:
+//   const { controller, dispose } = attachDragDrop(elem, handlers, { preventDefault: true });
+//   // to teardown:
+//   dispose(); // or controller.abort();
+export function attachDragDrop(element, handlers = {}, options = {}) {
+  if (!element || typeof element.addEventListener !== 'function') {
+    throw new Error('attachDragDrop: element must be a DOM node');
+  }
+
+  const {
+    onDragEnter = () => {},
+    onDragOver = () => {},
+    onDragLeave = () => {},
+    onDrop = () => {},
+  } = handlers;
+
+  const { preventDefault = true } = options;
+
+  // Prefer native AbortController when available, but do not rely on it for removal.
+  // We remove listeners explicitly in dispose() so tests/environments without
+  // abortable event listeners still work consistently.
+  const controller = (typeof AbortController !== 'undefined')
+    ? new AbortController()
+    : {
+        aborted: false,
+        signal: {
+          aborted: false,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        },
+        abort() { this.aborted = true; this.signal.aborted = true; try { dispose(); } catch {} },
+      };
+
+  // Named listener functions so they can be removed
+  function handleDragEnter(e) {
+    if (preventDefault && e && typeof e.preventDefault === 'function') e.preventDefault();
+    onDragEnter(e);
+  }
+  function handleDragOver(e) {
+    if (preventDefault && e && typeof e.preventDefault === 'function') e.preventDefault();
+    onDragOver(e);
+  }
+  function handleDragLeave(e) {
+    if (preventDefault && e && typeof e.preventDefault === 'function') e.preventDefault();
+    onDragLeave(e);
+  }
+  function handleDrop(e) {
+    if (preventDefault && e && typeof e.preventDefault === 'function') e.preventDefault();
+    onDrop(e);
+  }
+
+  element.addEventListener('dragenter', handleDragEnter);
+  element.addEventListener('dragover', handleDragOver);
+  element.addEventListener('dragleave', handleDragLeave);
+  element.addEventListener('drop', handleDrop);
+
+  // Dispose function to explicitly remove listeners.
+  function dispose() {
+    try { element.removeEventListener('dragenter', handleDragEnter); } catch {}
+    try { element.removeEventListener('dragover', handleDragOver); } catch {}
+    try { element.removeEventListener('dragleave', handleDragLeave); } catch {}
+    try { element.removeEventListener('drop', handleDrop); } catch {}
+    try { if (controller && typeof controller.abort === 'function' && !controller.aborted) { controller.aborted = true; } } catch {}
+  }
+
+  // If controller supports signals, abort should trigger dispose once.
+  try { controller.signal && controller.signal.addEventListener && controller.signal.addEventListener('abort', dispose, { once: true }); } catch {}
+
+  return { controller, dispose };
+}
+

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -234,7 +234,7 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
       onDragOver: (e) => onDragOver(e, topicAffix),
       onDragLeave: () => clearDrag(topicAffix),
       onDrop: (e) => onDrop(e, topicAffix),
-    }, { preventDefault: true });
+    }, { preventDefault: isBeta() });
   }
 
   function updateMirrorText(raw){

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -4,9 +4,13 @@ import { parseEditorInput } from './parser.js';
 import { generateWithAI } from './api.js?v=1.5.18';
 import { ImportController } from './import-controller.js';
 import { sniffFileKind, isSupportedImportKind } from './file-type-validation.js';
+import { attachDragDrop } from './drag-drop.js';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';
+
+// Keep reference to drag/drop wiring so re-init can dispose previous listeners
+let __topicAffixDragHandle = null;
 
 export function runParseFlow(sourceText, topicLabel, fullTitle){
   const mirror = $('mirror');
@@ -222,9 +226,16 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   const onDragOver = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.add('drag-on'); };
   const clearDrag = (el)=>{ el.classList.remove('drag-on'); };
   const onDrop = (e, el)=>{ if(!isBeta()) return; try{ e.preventDefault(); }catch{}; el.classList.remove('drag-on'); const dt=e.dataTransfer; if(!dt||!dt.files||!dt.files.length) return; handleImportFile(dt.files[0]); };
-  topicAffix?.addEventListener('dragover', (e)=> onDragOver(e, topicAffix));
-  topicAffix?.addEventListener('dragleave', ()=> clearDrag(topicAffix));
-  topicAffix?.addEventListener('drop', (e)=> onDrop(e, topicAffix));
+  // Use helper to attach listeners and ensure we can dispose on re-init
+  try { __topicAffixDragHandle?.dispose?.(); } catch {}
+  if (topicAffix) {
+    __topicAffixDragHandle = attachDragDrop(topicAffix, {
+      onDragEnter: (e) => onDragOver(e, topicAffix),
+      onDragOver: (e) => onDragOver(e, topicAffix),
+      onDragLeave: () => clearDrag(topicAffix),
+      onDrop: (e) => onDrop(e, topicAffix),
+    }, { preventDefault: true });
+  }
 
   function updateMirrorText(raw){
     if(!mirror) return;
@@ -658,4 +669,9 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
   }
   countUpBtn?.addEventListener('click', ()=> adjustCount(1));
   countDownBtn?.addEventListener('click', ()=> adjustCount(-1));
+}
+
+// Optional teardown for SPA navigation or re-init
+export function disposeGenerator(){
+  try { __topicAffixDragHandle?.dispose?.(); } catch {}
 }

--- a/tests/drag-drop.test.js
+++ b/tests/drag-drop.test.js
@@ -92,6 +92,17 @@ describe('attachDragDrop', () => {
     expect(enter).toHaveBeenCalledTimes(0);
   });
 
+  test('returns handle with controller and dispose', () => {
+    const drop = jest.fn();
+    const handle = attachDragDrop(elem, { onDrop: drop });
+    expect(handle && typeof handle).toBe('object');
+    expect(typeof handle.dispose).toBe('function');
+    expect(handle.controller).toBeTruthy();
+    // controller.abort may be a function in native or our fallback
+    expect(typeof handle.controller.abort).toBe('function');
+    handle.dispose();
+  });
+
   test('throws on invalid element', () => {
     expect(() => attachDragDrop(null)).toThrow(/DOM node/i);
     expect(() => attachDragDrop({})).toThrow();

--- a/tests/drag-drop.test.js
+++ b/tests/drag-drop.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { loadBrowserModule } = require('./utils');
+
+describe('attachDragDrop', () => {
+  let attachDragDrop;
+
+  beforeAll(() => {
+    ({ attachDragDrop } = loadBrowserModule('public/js/drag-drop.js', ['attachDragDrop']));
+  });
+
+  let elem;
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="affix"></div>';
+    elem = document.getElementById('affix');
+  });
+
+  test('attaches and invokes handlers once', () => {
+    const enter = jest.fn();
+    const drop = jest.fn();
+    const { dispose } = attachDragDrop(elem, { onDragEnter: enter, onDrop: drop });
+
+    elem.dispatchEvent(new Event('dragenter', { bubbles: true }));
+    expect(enter).toHaveBeenCalledTimes(1);
+
+    elem.dispatchEvent(new Event('drop', { bubbles: true }));
+    expect(drop).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  test('dispose removes listeners', () => {
+    const over = jest.fn();
+    const { dispose } = attachDragDrop(elem, { onDragOver: over });
+
+    elem.dispatchEvent(new Event('dragover', { bubbles: true }));
+    expect(over).toHaveBeenCalledTimes(1);
+
+    dispose();
+    // after dispose, calling should not call handler again
+    elem.dispatchEvent(new Event('dragover', { bubbles: true }));
+    expect(over).toHaveBeenCalledTimes(1);
+  });
+
+  test('re-attach after dispose does not duplicate listeners', () => {
+    const leave = jest.fn();
+    const handle1 = attachDragDrop(elem, { onDragLeave: leave });
+    handle1.dispose();
+
+    const handle2 = attachDragDrop(elem, { onDragLeave: leave });
+    elem.dispatchEvent(new Event('dragleave', { bubbles: true }));
+    expect(leave).toHaveBeenCalledTimes(1);
+
+    handle2.dispose();
+  });
+});
+

--- a/tests/drag-drop.test.js
+++ b/tests/drag-drop.test.js
@@ -53,5 +53,47 @@ describe('attachDragDrop', () => {
 
     handle2.dispose();
   });
-});
 
+  test('preventDefault is on by default', () => {
+    const over = jest.fn();
+    attachDragDrop(elem, { onDragOver: over });
+    const evt = new Event('dragover', { bubbles: true, cancelable: true });
+    elem.dispatchEvent(evt);
+    expect(over).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  test('preventDefault can be disabled', () => {
+    const over = jest.fn();
+    attachDragDrop(elem, { onDragOver: over }, { preventDefault: false });
+    const evt = new Event('dragover', { bubbles: true, cancelable: true });
+    elem.dispatchEvent(evt);
+    expect(over).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  test('controller.abort tears down listeners', () => {
+    const drop = jest.fn();
+    const handle = attachDragDrop(elem, { onDrop: drop });
+    elem.dispatchEvent(new Event('drop', { bubbles: true }));
+    expect(drop).toHaveBeenCalledTimes(1);
+    // Abort and ensure handler no longer fires
+    handle.controller.abort();
+    elem.dispatchEvent(new Event('drop', { bubbles: true }));
+    expect(drop).toHaveBeenCalledTimes(1);
+  });
+
+  test('dispose is idempotent', () => {
+    const enter = jest.fn();
+    const handle = attachDragDrop(elem, { onDragEnter: enter });
+    handle.dispose();
+    expect(() => handle.dispose()).not.toThrow();
+    elem.dispatchEvent(new Event('dragenter', { bubbles: true }));
+    expect(enter).toHaveBeenCalledTimes(0);
+  });
+
+  test('throws on invalid element', () => {
+    expect(() => attachDragDrop(null)).toThrow(/DOM node/i);
+    expect(() => attachDragDrop({})).toThrow();
+  });
+});


### PR DESCRIPTION
```markdown
# PR-002: Input Validation & Listener Lifecycle

Goal
- Ensure import validation is done early and consistently using magic-byte checks.
- Prevent drag/drop and other event listeners from accumulating when UI is re-initialized.
- Provide an idempotent attach/teardown API for drag/drop so re-initialization (hot reload, SPA re-render) does not leak listeners.
- Expose a clear disposal mechanism (AbortController or dispose()) to remove listeners.

Out of scope
- Race-condition/ImportController logic (PR-001).
- Accessibility copy changes (separate PR).
- Complex refactor of UI components.

Affected areas
- src/generator.js (wiring of drag/drop and import affix)
- src/utils/dragDrop.js (new helper)
- unit tests for dragDrop helper

High-level approach
1. Add magic-byte sniffing in PR-001 (if not present). Use it here to gate early.
2. Implement a small, well-tested helper attachDragDrop(element, handlers, options) that:
   - Attaches dragover, dragenter, dragleave, drop listeners.
   - Uses an AbortController so callers can cancel/teardown all listeners.
   - Returns { controller, dispose } for explicit teardown.
   - Is safe to call multiple times on the same element: caller must hold previous controller and dispose it first (we show an example).
3. Update generator.js initialization:
   - Keep a reference to the current dragDrop controller/handle.
   - On re-init, dispose prior controller before attaching new listeners.
   - Prefer a single place where wiring happens; make wiring idempotent.
4. Add unit tests for attachDragDrop verifying:
   - Listeners are attached and invoked on events.
   - dispose() / controller.abort() removes listeners.
   - Re-attaching after dispose works and does not cause duplicate invocations.

Acceptance criteria
- Re-initializing wiring multiple times does not cause handlers to fire more than once per event.
- All attached drag/drop listeners can be removed via dispose() or controller.abort().
- Unit tests cover attachment, invocation, teardown, and re-attach behavior.

Test plan
- Unit tests (jest + jsdom):
  - Simulate dragenter/dragover/drop events; assert handler called once.
  - After dispose(), simulate again; assert handler not called.
  - Re-attach and simulate; assert handler called once (no duplicates).

Checklist
- [ ] New dragDrop helper implemented and exported
- [ ] generator.js uses helper and disposes previous listeners on re-init
- [ ] Unit tests added
- [ ] PR description added and screenshots of behavior included (if applicable)
```