### PR TITLE
PR-002: DragDrop test polish

### DIFF
--- a/tests/drag-drop.test.js
+++ b/tests/drag-drop.test.js
@@ -92,6 +92,17 @@ describe('attachDragDrop', () => {
     expect(enter).toHaveBeenCalledTimes(0);
   });
 
+  test('returns handle with controller and dispose', () => {
+    const drop = jest.fn();
+    const handle = attachDragDrop(elem, { onDrop: drop });
+    expect(handle && typeof handle).toBe('object');
+    expect(typeof handle.dispose).toBe('function');
+    expect(handle.controller).toBeTruthy();
+    // controller.abort may be a function in native or our fallback
+    expect(typeof handle.controller.abort).toBe('function');
+    handle.dispose();
+  });
+
   test('throws on invalid element', () => {
     expect(() => attachDragDrop(null)).toThrow(/DOM node/i);
     expect(() => attachDragDrop({})).toThrow();


### PR DESCRIPTION
- Converts reference test intent into project-aligned Jest coverage\n- Adds handle shape assertion (controller and dispose)\n- Tests already cover: attach/invoke, dispose stops listeners, re-attach without duplicates, preventDefault on/off, controller.abort, idempotent dispose, invalid element\n\nBase: chore/pr-002-listener-lifecycle\nThis PR targets the PR-002 branch to land incremental test improvements without touching main.