### PR TITLE
fix: restore beta redirect on settings close

### DIFF
--- a/issues/Review-recent-commits-QA-summary.md
+++ b/issues/Review-recent-commits-QA-summary.md
@@ -1,0 +1,21 @@
+# Review: recent commits QA summary
+
+## Commits / PRs reviewed (last 7 days)
+- `2412352` (PR #67) — accessibility polish: added `public/js/a11y-announcer.js`, wired announcer + drag-drop cleanup in `public/js/generator.js`, refreshed cache-busters in `public/index.html`, `public/js/main.js`, `public/js/editor.gui.js`, and `public/sw.js`.
+- `278f875` (PR #65) / `62873a4` (PR #66) — drag/drop helper + beta gating adjustments (`public/js/drag-drop.js`, `public/js/generator.js`).
+- Direct commits `e159c80`, `e952e9a`, `1c40c81`, `067972a`, `18abc85` — beta routing and auto-refresh updates in `public/js/main.js`, `public/js/modals.js`, `public/js/settings.js`, `public/js/auto-refresh.js`, and `netlify/edge-functions/beta.ts`.
+
+## Checklist results
+| Layer | Status | Notes |
+| --- | --- | --- |
+| HTML | ✅ Pass | Cache-buster refresh kept IDs/hooks intact. Help/Settings/Results anchors unchanged. |
+| CSS | ✅ Pass | No new CSS in this window; existing tokens unaffected. |
+| JS | ⚠️ Fail (Addressed) | PR #67 logic routes through existing modules; drag/drop helper disposes cleanly; beta redirects (`public/js/main.js`) work. However commit `18abc85` cleared the Settings-modal redirect hook, so enabling Beta no longer navigates to `/beta`. Fix provided in this PR by restoring the pending redirect handler (`public/js/modals.js`). |
+| Netlify | ✅ Pass | `netlify/edge-functions/beta.ts` now uses `context.next()`; headers preserved. |
+
+## Testing / Verification
+- ✅ `npm test --silent`
+- Manual Deploy Preview: not run (changes validated via static review; bug reproduced analytically).
+
+## Outcome / Next steps
+- Opened fix PR: restores Settings close redirect handling so Beta enablement navigates to `/beta` again.

--- a/issues/Review-recent-commits-QA-summary.md
+++ b/issues/Review-recent-commits-QA-summary.md
@@ -10,7 +10,7 @@
 | --- | --- | --- |
 | HTML | ✅ Pass | Cache-buster refresh kept IDs/hooks intact. Help/Settings/Results anchors unchanged. |
 | CSS | ✅ Pass | No new CSS in this window; existing tokens unaffected. |
-| JS | ⚠️ Fail (Addressed) | PR #67 logic routes through existing modules; drag/drop helper disposes cleanly; beta redirects (`public/js/main.js`) work. However commit `18abc85` cleared the Settings-modal redirect hook, so enabling Beta no longer navigates to `/beta`. Fix provided in this PR by restoring the pending redirect handler (`public/js/modals.js`). |
+| JS | ⚠️ Fail (Addressed) | PR #67 logic routes through existing modules; drag/drop helper disposes cleanly; beta redirects (`public/js/main.js`) work. However commit `18abc85` cleared the Settings-modal redirect hook, so enabling Beta no longer navigates to `/beta`. Fix provided in this PR by restoring the pending redirect handler (`public/js/modals.js`) and covering backdrop dismissals. |
 | Netlify | ✅ Pass | `netlify/edge-functions/beta.ts` now uses `context.next()`; headers preserved. |
 
 ## Testing / Verification

--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -13,6 +13,33 @@ export function openModal(id){
 }
 export function closeModal(id){ const el=document.getElementById(id); if(!el) return; el.classList.remove('is-open'); el.setAttribute('aria-hidden','true'); }
 
+function handleSettingsClosed(onResume){
+  try{
+    const g = (window.__EZQ__ = window.__EZQ__ || {});
+    const pendingTarget = g.__betaPendingRedirect;
+    if(pendingTarget){
+      g.__betaPendingRedirect = null;
+      g.__betaRefreshPending = false;
+      if(onResume) onResume();
+      setTimeout(()=>{
+        try{ window.location.replace(pendingTarget); }
+        catch{ window.location.href = pendingTarget; }
+      }, 60);
+      return true;
+    }
+    if(g.__betaRefreshPending){
+      g.__betaRefreshPending = false;
+      if(onResume) onResume();
+      setTimeout(()=>{
+        try{ window.location.reload(true); }
+        catch{ window.location.reload(); }
+      }, 60);
+      return true;
+    }
+  }catch{}
+  return false;
+}
+
 export function wireModals({ onPause, onResume }){
   const map = {
     helpBtn:'helpModal',
@@ -44,28 +71,21 @@ export function wireModals({ onPause, onResume }){
     const btn=document.getElementById(btnId);
     btn?.addEventListener('click', ()=>{
       closeModal(modalId);
-      // If Settings was closed and a beta refresh is pending, reload softly
-      if(modalId === 'settingsModal'){
-        try{
-          const g = (window.__EZQ__ = window.__EZQ__ || {});
-          const pendingTarget = g.__betaPendingRedirect;
-          if(pendingTarget){
-            g.__betaPendingRedirect = null;
-            g.__betaRefreshPending = false;
-            if(onResume) onResume();
-            setTimeout(()=>{
-              try{ window.location.replace(pendingTarget); }
-              catch{ window.location.href = pendingTarget; }
-            }, 60);
-            return;
-          }
-          if(g.__betaRefreshPending){ g.__betaRefreshPending = false; if(onResume) onResume(); setTimeout(()=>{ try{ window.location.reload(true); }catch{ window.location.reload(); } }, 60); return; }
-        }catch{}
-      }
+      if(modalId === 'settingsModal' && handleSettingsClosed(onResume)) return;
       if(onResume) onResume();
     });
   });
-  document.addEventListener('click', (e)=>{ const t=e.target; if(t && t.matches('.modal__backdrop')){ const id=t.getAttribute('data-close'); if(id){ closeModal(id); if(onResume) onResume(); } } });
+  document.addEventListener('click', (e)=>{
+    const t=e.target;
+    if(t && t.matches('.modal__backdrop')){
+      const id=t.getAttribute('data-close');
+      if(id){
+        closeModal(id);
+        if(id==='settingsModal' && handleSettingsClosed(onResume)) return;
+        if(onResume) onResume();
+      }
+    }
+  });
 
   // Help accordion: only one open at a time
   const helpModal = document.getElementById('helpModal');

--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -48,6 +48,17 @@ export function wireModals({ onPause, onResume }){
       if(modalId === 'settingsModal'){
         try{
           const g = (window.__EZQ__ = window.__EZQ__ || {});
+          const pendingTarget = g.__betaPendingRedirect;
+          if(pendingTarget){
+            g.__betaPendingRedirect = null;
+            g.__betaRefreshPending = false;
+            if(onResume) onResume();
+            setTimeout(()=>{
+              try{ window.location.replace(pendingTarget); }
+              catch{ window.location.href = pendingTarget; }
+            }, 60);
+            return;
+          }
           if(g.__betaRefreshPending){ g.__betaRefreshPending = false; if(onResume) onResume(); setTimeout(()=>{ try{ window.location.reload(true); }catch{ window.location.reload(); } }, 60); return; }
         }catch{}
       }


### PR DESCRIPTION
## Summary
- restore the Settings modal close handler so pending beta redirects navigate to the queued target before falling back to refreshes
- record the review findings in `issues/Review-recent-commits-QA-summary.md`

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68fad307edd883299857d19ff28e3898