### PR TITLE
chore: release v3.4.0 metadata sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,3 +165,16 @@ Changelog
 - FAQ modal: single scrollbar; Close button always visible.
 - Security: no innerHTML for user content; tightened CSP; no inline scripts.
 - PWA: relative paths; SW cache bumps; Netlify headers + HTTPS redirects.
+
+## [3.4.0] - 2025-11-01
+### Added
+- README restored to lean layout with live Netlify deploy badge and upstream synced mirror badge.
+
+### Changed
+- Security hardening for GitHub Actions: least privilege tokens, pinned actions to immutable SHAs.
+- SECURITY.md expanded with advisory link, contact email, and response timelines.
+- Mirror workflows cleaned up for safer sync to public repo.
+- Minor UI text and docs polish.
+
+### Fixed
+- Version mismatch risks in footer and docs by aligning package.json, footer, and release tag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ez-quiz-app",
-  "version": "1.5.0-beta.11",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ez-quiz-app",
-      "version": "1.5.0-beta.11",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-quiz-app",
-  "version": "1.5.0-beta.12",
+  "version": "3.4.0",
   "private": true,
   "license": "MIT",
   "description": "Static PWA + Netlify Functions for EZ Quiz",

--- a/public/index.html
+++ b/public/index.html
@@ -458,7 +458,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
         </fieldset>
 
         <p class="muted small settings-version" data-version-copy>
-          Version <a id="versionInfoBtn" href="#" aria-haspopup="dialog" aria-controls="releaseNotesModal" data-version-label>v3.3</a>
+          Version <a id="versionInfoBtn" href="#" aria-haspopup="dialog" aria-controls="releaseNotesModal" data-version-label>v3.4.0</a>
           <span aria-hidden="true">·</span>
           <span data-version-mode>Production</span> build
         </p>
@@ -479,7 +479,7 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
       </header>
       <div class="modal__body">
         <section class="release-notes release-notes--production">
-          <h4>v3.3</h4>
+          <h4>v3.4.0</h4>
           <ul>
             <li>Stable AI fallback loop now ships to everyone.</li>
             <li>All recent UI polish and cache busts are part of the main app.</li>


### PR DESCRIPTION
## Summary
- bump the project metadata to version 3.4.0 for the v3.4 release
- refresh the site footer modal copy so it advertises v3.4.0
- append the 3.4.0 entry to the changelog with release highlights

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69062a0315cc8329a6006a487070554e