### PR TITLE
Refine theme preload flow and deduplicate tokens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,22 +8,33 @@
   <link rel="icon" href="icons/icon-192.png" />
   <script>
     (function(){
+      var root = document.documentElement;
       var KEY = 'ezq.theme';
       var stored = 'system';
-      var applied;
-      var choice;
+      try {
+        root.setAttribute('data-theme-pending', '1');
+        root.setAttribute('aria-busy', 'true');
+      } catch (err) {}
       var syncTheme = function(choiceValue, appliedValue){
         var previous = window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied;
-        try { document.documentElement.setAttribute('data-theme', appliedValue); } catch (err) {}
-        try { document.documentElement.classList.add('theme-ready'); } catch (err) {}
+        try { root.setAttribute('data-theme', appliedValue); } catch (err) {}
+        try {
+          root.classList.add('theme-ready');
+          root.removeAttribute('data-theme-pending');
+          root.removeAttribute('aria-busy');
+        } catch (err) {}
         window.__EZQ_PRELOADED_THEME = { choice: choiceValue, applied: appliedValue, previous: previous };
       };
       window.__EZQ_SYNC_THEME = syncTheme;
-      var handleSystemChange = function(matches){
-        if ((window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.choice) === 'system') {
-          syncTheme('system', matches ? 'dark' : 'light');
-        }
+      var createSystemThemeHandler = window.__EZQ_CREATE_SYSTEM_THEME_HANDLER || function(syncFn){
+        return function(matches){
+          if ((window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.choice) === 'system') {
+            syncFn('system', matches ? 'dark' : 'light');
+          }
+        };
       };
+      window.__EZQ_CREATE_SYSTEM_THEME_HANDLER = createSystemThemeHandler;
+      var handleSystemChange = createSystemThemeHandler(syncTheme);
       window.__EZQ_SYSTEM_THEME_HANDLER = handleSystemChange;
       try {
         var raw = localStorage.getItem(KEY);
@@ -31,20 +42,26 @@
           stored = raw;
         }
       } catch (err) {}
-      choice = stored;
-      if (stored === 'light' || stored === 'dark') {
-        applied = stored;
-      } else {
+      var choice = stored;
+      var applied = choice;
+      if (choice !== 'light' && choice !== 'dark') {
         applied = 'dark';
         try {
           var mq = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
           applied = mq && mq.matches ? 'dark' : 'light';
           window.__EZQ_SYSTEM_MQL = mq;
+          var listener = function(ev){
+            var fn = window.__EZQ_SYSTEM_THEME_HANDLER || handleSystemChange;
+            if (typeof fn === 'function') {
+              fn(ev.matches);
+            }
+          };
           if (mq && mq.addEventListener) {
-            mq.addEventListener('change', function(ev){ handleSystemChange(ev.matches); });
+            mq.addEventListener('change', listener);
           } else if (mq && mq.addListener) {
-            mq.addListener(function(ev){ handleSystemChange(ev.matches); });
+            mq.addListener(listener);
           }
+          window.__EZQ_SYSTEM_THEME_LISTENER = listener;
         } catch (err) { applied = 'dark'; }
       }
       syncTheme(choice, applied || 'dark');

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -64,17 +64,21 @@ export function applyTheme(theme){
   }
   // window.__EZQ_PRELOADED_THEME synchronises the inline preload script with runtime updates.
   // Shape: { choice: 'light'|'dark'|'system', applied: 'light'|'dark', previous?: 'light'|'dark' }
+  // The inline script also reads `choice` to decide whether to follow system changes, so always
+  // keep that field aligned with the latest preference.
   try{
     const sync = (typeof window !== 'undefined' && window.__EZQ_SYNC_THEME);
-    if(typeof sync === 'function'){
-      sync(t, eff);
-    }else{
+    const fallbackSync = (choiceValue, appliedValue)=>{
       const root = document.documentElement;
       const previous = (window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied) || root.getAttribute('data-theme');
-      root.setAttribute('data-theme', eff);
+      root.setAttribute('data-theme', appliedValue);
       root.classList.add('theme-ready');
-      window.__EZQ_PRELOADED_THEME = { choice: t, applied: eff, previous };
-    }
+      root.removeAttribute('data-theme-pending');
+      root.removeAttribute('aria-busy');
+      window.__EZQ_PRELOADED_THEME = { choice: choiceValue, applied: appliedValue, previous };
+    };
+    const effectiveSync = (typeof sync === 'function') ? sync : fallbackSync;
+    effectiveSync(t, eff);
   }catch{}
   // Swap brand logo asset based on theme, with simple, explicit mapping
   try{
@@ -97,30 +101,42 @@ export function applyTheme(theme){
     const m=ensureMql();
     if(m){
       if(t==='system'){
-        const handler = (typeof window !== 'undefined' && window.__EZQ_SYSTEM_THEME_HANDLER) || ((matches)=>{
+        const factory = (typeof window !== 'undefined' && window.__EZQ_CREATE_SYSTEM_THEME_HANDLER);
+        const fallbackFactory = (syncFn)=>((matches)=>{
           if((window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.choice) === 'system'){
-            const sync = window.__EZQ_SYNC_THEME;
             const next = matches ? 'dark' : 'light';
-            if(typeof sync === 'function'){
-              sync('system', next);
-            }else{
-              const root = document.documentElement;
-              root.setAttribute('data-theme', next);
-              root.classList.add('theme-ready');
-              const prev = window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied;
-              window.__EZQ_PRELOADED_THEME = { choice: 'system', applied: next, previous: prev };
-            }
+            syncFn('system', next);
           }
         });
+        const sync = (typeof window !== 'undefined' && window.__EZQ_SYNC_THEME);
+        const fallbackSync = (choiceValue, appliedValue)=>{
+          const root = document.documentElement;
+          root.setAttribute('data-theme', appliedValue);
+          root.classList.add('theme-ready');
+          root.removeAttribute('data-theme-pending');
+          root.removeAttribute('aria-busy');
+          const prev = window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied;
+          window.__EZQ_PRELOADED_THEME = { choice: choiceValue, applied: appliedValue, previous: prev };
+        };
+        const effectiveSync = (typeof sync === 'function') ? sync : fallbackSync;
+        const handlerFactory = (typeof factory === 'function') ? factory : fallbackFactory;
+        const handler = handlerFactory(effectiveSync);
+        if(typeof window !== 'undefined'){ window.__EZQ_SYSTEM_THEME_HANDLER = handler; }
         if(!applyTheme._bound){
-          const listener = (ev)=>{ if(S.settings.theme==='system'){ handler(ev.matches); } };
-          if(m.addEventListener){
-            m.addEventListener('change', listener);
-          }else if(m.addListener){
-            m.addListener(listener);
+          const existing = (typeof window !== 'undefined' && window.__EZQ_SYSTEM_THEME_LISTENER);
+          if(existing){
+            applyTheme._listener = existing;
+            applyTheme._bound = true;
+          }else{
+            const listener = (ev)=>{ if(S.settings.theme==='system'){ handler(ev.matches); } };
+            if(m.addEventListener){
+              m.addEventListener('change', listener);
+            }else if(m.addListener){
+              m.addListener(listener);
+            }
+            applyTheme._listener = listener;
+            applyTheme._bound = true;
           }
-          applyTheme._listener = listener;
-          applyTheme._bound = true;
         }
         handler(m.matches);
       }else if(applyTheme._bound && applyTheme._listener){

--- a/public/styles.css
+++ b/public/styles.css
@@ -148,7 +148,9 @@ html{font-size:var(--fz-2); line-height:var(--lh-2);}
   color-scheme: dark;
 }
 
+html[data-theme-pending] body,
 html[data-theme]:not(.theme-ready) body{opacity:0; pointer-events:none; user-select:none;}
+html.theme-ready body{opacity:1; pointer-events:auto; user-select:auto;}
 body{margin:0; min-height:100vh; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; background:var(--bg); color:var(--text); display:flex; flex-direction:column;}
 main{flex:1;}
 a{color:inherit; text-decoration:none; transition:color var(--dur-1) var(--easing);}

--- a/public/styles.tokens.css
+++ b/public/styles.tokens.css
@@ -60,74 +60,86 @@
 
   /* Default to dark theme until data-theme applies */
   color-scheme: dark;
-  --surface-0: var(--theme-dark-surface-0);
-  --surface-1: var(--theme-dark-surface-1);
-  --surface-2: var(--theme-dark-surface-2);
-  --text:      var(--theme-dark-text);
-  --muted:     var(--theme-dark-muted);
-  --hairline:  var(--theme-dark-hairline);
-  --accent:    var(--theme-dark-accent);
-  --accent-contrast: var(--theme-dark-contrast);
-  --elev-1: var(--theme-dark-elev-1);
-  --elev-2: var(--theme-dark-elev-2);
+  --theme-surface-0: var(--theme-dark-surface-0);
+  --theme-surface-1: var(--theme-dark-surface-1);
+  --theme-surface-2: var(--theme-dark-surface-2);
+  --theme-text:      var(--theme-dark-text);
+  --theme-muted:     var(--theme-dark-muted);
+  --theme-hairline:  var(--theme-dark-hairline);
+  --theme-accent:    var(--theme-dark-accent);
+  --theme-accent-contrast: var(--theme-dark-contrast);
+  --theme-elev-1: var(--theme-dark-elev-1);
+  --theme-elev-2: var(--theme-dark-elev-2);
+
+  /* Public tokens consume the currently active theme aliases */
+  --surface-0: var(--theme-surface-0);
+  --surface-1: var(--theme-surface-1);
+  --surface-2: var(--theme-surface-2);
+  --text:      var(--theme-text);
+  --muted:     var(--theme-muted);
+  --hairline:  var(--theme-hairline);
+  --accent:    var(--theme-accent);
+  --accent-contrast: var(--theme-accent-contrast);
+  --elev-1: var(--theme-elev-1);
+  --elev-2: var(--theme-elev-2);
 }
 
 :root[data-theme="light"] {
   color-scheme: light;
-  --surface-0: var(--theme-light-surface-0);
-  --surface-1: var(--theme-light-surface-1);
-  --surface-2: var(--theme-light-surface-2);
-  --text:      var(--theme-light-text);
-  --muted:     var(--theme-light-muted);
-  --hairline:  var(--theme-light-hairline);
-  --accent:    var(--theme-light-accent);
-  --accent-contrast: var(--theme-light-contrast);
-  --elev-1: var(--theme-light-elev-1);
-  --elev-2: var(--theme-light-elev-2);
+  --theme-surface-0: var(--theme-light-surface-0);
+  --theme-surface-1: var(--theme-light-surface-1);
+  --theme-surface-2: var(--theme-light-surface-2);
+  --theme-text:      var(--theme-light-text);
+  --theme-muted:     var(--theme-light-muted);
+  --theme-hairline:  var(--theme-light-hairline);
+  --theme-accent:    var(--theme-light-accent);
+  --theme-accent-contrast: var(--theme-light-contrast);
+  --theme-elev-1: var(--theme-light-elev-1);
+  --theme-elev-2: var(--theme-light-elev-2);
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
-  --surface-0: var(--theme-dark-surface-0);
-  --surface-1: var(--theme-dark-surface-1);
-  --surface-2: var(--theme-dark-surface-2);
-  --text:      var(--theme-dark-text);
-  --muted:     var(--theme-dark-muted);
-  --hairline:  var(--theme-dark-hairline);
-  --accent:    var(--theme-dark-accent);
-  --accent-contrast: var(--theme-dark-contrast);
-  --elev-1: var(--theme-dark-elev-1);
-  --elev-2: var(--theme-dark-elev-2);
+  --theme-surface-0: var(--theme-dark-surface-0);
+  --theme-surface-1: var(--theme-dark-surface-1);
+  --theme-surface-2: var(--theme-dark-surface-2);
+  --theme-text:      var(--theme-dark-text);
+  --theme-muted:     var(--theme-dark-muted);
+  --theme-hairline:  var(--theme-dark-hairline);
+  --theme-accent:    var(--theme-dark-accent);
+  --theme-accent-contrast: var(--theme-dark-contrast);
+  --theme-elev-1: var(--theme-dark-elev-1);
+  --theme-elev-2: var(--theme-dark-elev-2);
 }
 
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
     color-scheme: light;
-    --surface-0: var(--theme-light-surface-0);
-    --surface-1: var(--theme-light-surface-1);
-    --surface-2: var(--theme-light-surface-2);
-    --text:      var(--theme-light-text);
-    --muted:     var(--theme-light-muted);
-    --hairline:  var(--theme-light-hairline);
-    --accent:    var(--theme-light-accent);
-    --accent-contrast: var(--theme-light-contrast);
-    --elev-1: var(--theme-light-elev-1);
-    --elev-2: var(--theme-light-elev-2);
+    --theme-surface-0: var(--theme-light-surface-0);
+    --theme-surface-1: var(--theme-light-surface-1);
+    --theme-surface-2: var(--theme-light-surface-2);
+    --theme-text:      var(--theme-light-text);
+    --theme-muted:     var(--theme-light-muted);
+    --theme-hairline:  var(--theme-light-hairline);
+    --theme-accent:    var(--theme-light-accent);
+    --theme-accent-contrast: var(--theme-light-contrast);
+    --theme-elev-1: var(--theme-light-elev-1);
+    --theme-elev-2: var(--theme-light-elev-2);
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
     color-scheme: dark;
-    --surface-0: var(--theme-dark-surface-0);
-    --surface-1: var(--theme-dark-surface-1);
-    --surface-2: var(--theme-dark-surface-2);
-    --text:      var(--theme-dark-text);
-    --muted:     var(--theme-dark-muted);
-    --hairline:  var(--theme-dark-hairline);
-    --accent:    var(--theme-dark-accent);
-    --accent-contrast: var(--theme-dark-contrast);
-    --elev-1: var(--theme-dark-elev-1);
-    --elev-2: var(--theme-dark-elev-2);
+    --theme-surface-0: var(--theme-dark-surface-0);
+    --theme-surface-1: var(--theme-dark-surface-1);
+    --theme-surface-2: var(--theme-dark-surface-2);
+    --theme-text:      var(--theme-dark-text);
+    --theme-muted:     var(--theme-dark-muted);
+    --theme-hairline:  var(--theme-dark-hairline);
+    --theme-accent:    var(--theme-dark-accent);
+    --theme-accent-contrast: var(--theme-dark-contrast);
+    --theme-elev-1: var(--theme-dark-elev-1);
+    --theme-elev-2: var(--theme-dark-elev-2);
   }
 }


### PR DESCRIPTION
## Summary
- deduplicate light/dark token assignments by introducing intermediate theme aliases
- share the system-theme handler between the preload script and settings module and document the preload contract
- mark the DOM as busy while the theme is pending and restore opacity via a reusable attribute rather than visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690ad49e486c8329801d41fd46f60d26