### PR TITLE
Restore theme bootstrapper under CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,71 +6,11 @@
   <title>EZ Quiz</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" />
-  <script>
-    (function(){
-      var root = document.documentElement;
-      var KEY = 'ezq.theme';
-      var stored = 'system';
-      try {
-        root.setAttribute('data-theme-pending', '1');
-        root.setAttribute('aria-busy', 'true');
-      } catch (err) {}
-      var syncTheme = function(choiceValue, appliedValue){
-        var previous = window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied;
-        try { root.setAttribute('data-theme', appliedValue); } catch (err) {}
-        try {
-          root.classList.add('theme-ready');
-          root.removeAttribute('data-theme-pending');
-          root.removeAttribute('aria-busy');
-        } catch (err) {}
-        window.__EZQ_PRELOADED_THEME = { choice: choiceValue, applied: appliedValue, previous: previous };
-      };
-      window.__EZQ_SYNC_THEME = syncTheme;
-      var createSystemThemeHandler = window.__EZQ_CREATE_SYSTEM_THEME_HANDLER || function(syncFn){
-        return function(matches){
-          if ((window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.choice) === 'system') {
-            syncFn('system', matches ? 'dark' : 'light');
-          }
-        };
-      };
-      window.__EZQ_CREATE_SYSTEM_THEME_HANDLER = createSystemThemeHandler;
-      var handleSystemChange = createSystemThemeHandler(syncTheme);
-      window.__EZQ_SYSTEM_THEME_HANDLER = handleSystemChange;
-      try {
-        var raw = localStorage.getItem(KEY);
-        if (raw === 'light' || raw === 'dark' || raw === 'system') {
-          stored = raw;
-        }
-      } catch (err) {}
-      var choice = stored;
-      var applied = choice;
-      if (choice !== 'light' && choice !== 'dark') {
-        applied = 'dark';
-        try {
-          var mq = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
-          applied = mq && mq.matches ? 'dark' : 'light';
-          window.__EZQ_SYSTEM_MQL = mq;
-          var listener = function(ev){
-            var fn = window.__EZQ_SYSTEM_THEME_HANDLER || handleSystemChange;
-            if (typeof fn === 'function') {
-              fn(ev.matches);
-            }
-          };
-          if (mq && mq.addEventListener) {
-            mq.addEventListener('change', listener);
-          } else if (mq && mq.addListener) {
-            mq.addListener(listener);
-          }
-          window.__EZQ_SYSTEM_THEME_LISTENER = listener;
-        } catch (err) { applied = 'dark'; }
-      }
-      syncTheme(choice, applied || 'dark');
-    })();
-  </script>
-  <link rel="stylesheet" href="styles.css?v=1.5.22" />
-  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.22">
-  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.22">
-  <script src="js/boot-beta.js?v=1.5.22"></script>
+  <script src="js/theme-preload.js?v=1.5.23"></script>
+  <link rel="stylesheet" href="styles.css?v=1.5.23" />
+  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.23">
+  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.23">
+  <script src="js/boot-beta.js?v=1.5.23"></script>
 </head>
 <body>
   <header class="site-header" role="banner">
@@ -701,10 +641,10 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   
 
-  <script type="module" src="js/main.js?v=1.5.22"></script>
-  <script type="module" src="js/auto-refresh.js?v=1.5.22"></script>
-  <script type="module" src="js/patches.js?v=1.5.22"></script>
-  <script type="module" src="js/editor.gui.js?v=1.5.22"></script>
+  <script type="module" src="js/main.js?v=1.5.23"></script>
+  <script type="module" src="js/auto-refresh.js?v=1.5.23"></script>
+  <script type="module" src="js/patches.js?v=1.5.23"></script>
+  <script type="module" src="js/editor.gui.js?v=1.5.23"></script>
 
   <!-- Floating actions: Feedback + Coffee -->
   <div id="floatingActions" class="fab-stack" aria-label="Quick actions">

--- a/public/js/editor.gui.js
+++ b/public/js/editor.gui.js
@@ -1,6 +1,6 @@
 // Interactive Editor (beta) — rebuilt v2
 // Simple, robust, no global delegation; uses pointerdown to beat Options capture
-import { runParseFlow } from './generator.js?v=1.5.22';
+import { runParseFlow } from './generator.js?v=1.5.23';
 
 const IE2 = (()=>{
   const SKEY = 'ezq.ie.v2.on';

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -1,12 +1,12 @@
 import { S } from './state.js';
 import { $, byQSA, mmSsToMs, clampCount, getMaxQuestions } from './utils.js';
 import { parseEditorInput } from './parser.js';
-import { generateWithAI } from './api.js?v=1.5.22';
+import { generateWithAI } from './api.js?v=1.5.23';
 import { ImportController } from './import-controller.js';
 import { sniffFileKind, isSupportedImportKind } from './file-type-validation.js';
 import { attachDragDrop } from './drag-drop.js';
-import { announce } from './a11y-announcer.js?v=1.5.22';
-import { buildGeneratorPayload } from './generator-payload.js?v=1.5.22';
+import { announce } from './a11y-announcer.js?v=1.5.23';
+import { buildGeneratorPayload } from './generator-payload.js?v=1.5.23';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,7 +2,7 @@ import { S } from './state.js';
 import { $, byQSA, showUpdateBannerIfReady } from './utils.js';
 import { loadSettingsFromStorage, applyTheme, reflectSettingsIntoUI, wireSettingsPanel } from './settings.js';
 import { wireModals } from './modals.js';
-import { wireGenerator } from './generator.js?v=1.5.22';
+import { wireGenerator } from './generator.js?v=1.5.23';
 import { setMode, beginQuiz, renderCurrentQuestion, updateNavButtons, updateProgress, wireQuizControls, wireResultsControls, pauseTimerIfQuiz, resumeTimerIfQuiz, syncSettingsFromUI } from './quiz.js';
 import { has as hasFlag, hasCookie as hasCookieFlag } from './flags.js';
 

--- a/public/js/theme-preload.js
+++ b/public/js/theme-preload.js
@@ -1,0 +1,59 @@
+(function(){
+  var root = document.documentElement;
+  var KEY = 'ezq.theme';
+  var stored = 'system';
+  try {
+    root.setAttribute('data-theme-pending', '1');
+    root.setAttribute('aria-busy', 'true');
+  } catch (err) {}
+  var syncTheme = function(choiceValue, appliedValue){
+    var previous = window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.applied;
+    try { root.setAttribute('data-theme', appliedValue); } catch (err) {}
+    try {
+      root.classList.add('theme-ready');
+      root.removeAttribute('data-theme-pending');
+      root.removeAttribute('aria-busy');
+    } catch (err) {}
+    window.__EZQ_PRELOADED_THEME = { choice: choiceValue, applied: appliedValue, previous: previous };
+  };
+  window.__EZQ_SYNC_THEME = syncTheme;
+  var createSystemThemeHandler = window.__EZQ_CREATE_SYSTEM_THEME_HANDLER || function(syncFn){
+    return function(matches){
+      if ((window.__EZQ_PRELOADED_THEME && window.__EZQ_PRELOADED_THEME.choice) === 'system') {
+        syncFn('system', matches ? 'dark' : 'light');
+      }
+    };
+  };
+  window.__EZQ_CREATE_SYSTEM_THEME_HANDLER = createSystemThemeHandler;
+  var handleSystemChange = createSystemThemeHandler(syncTheme);
+  window.__EZQ_SYSTEM_THEME_HANDLER = handleSystemChange;
+  try {
+    var raw = localStorage.getItem(KEY);
+    if (raw === 'light' || raw === 'dark' || raw === 'system') {
+      stored = raw;
+    }
+  } catch (err) {}
+  var choice = stored;
+  var applied = choice;
+  if (choice !== 'light' && choice !== 'dark') {
+    applied = 'dark';
+    try {
+      var mq = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+      applied = mq && mq.matches ? 'dark' : 'light';
+      window.__EZQ_SYSTEM_MQL = mq;
+      var listener = function(ev){
+        var fn = window.__EZQ_SYSTEM_THEME_HANDLER || handleSystemChange;
+        if (typeof fn === 'function') {
+          fn(ev.matches);
+        }
+      };
+      if (mq && mq.addEventListener) {
+        mq.addEventListener('change', listener);
+      } else if (mq && mq.addListener) {
+        mq.addListener(listener);
+      }
+      window.__EZQ_SYSTEM_THEME_LISTENER = listener;
+    } catch (err) { applied = 'dark'; }
+  }
+  syncTheme(choice, applied || 'dark');
+})();

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,13 +8,14 @@
  * page for navigation requests when offline.
  */
 
-const ASSET_VERSION = '1.5.22';
-const CACHE_NAME = 'ezq-v1206';
+const ASSET_VERSION = '1.5.23';
+const CACHE_NAME = 'ezq-v1207';
 const PRECACHE_URLS = [
   '/index.html',
   '/styles.css?v=' + ASSET_VERSION,
   '/styles.tokens.css?v=' + ASSET_VERSION,
   '/styles.backdrop.css?v=' + ASSET_VERSION,
+  '/js/theme-preload.js?v=' + ASSET_VERSION,
   '/js/boot-beta.js?v=' + ASSET_VERSION,
   '/js/main.js?v=' + ASSET_VERSION,
   '/js/auto-refresh.js?v=' + ASSET_VERSION,


### PR DESCRIPTION
## Summary
- move the theme bootstrapper into a standalone script so it runs under the tightened CSP and restores pointer events
- bump the asset version to 1.5.23 and update cache busting along with the service worker precache list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690b5cb3c1948329a39dd6cda4bcd574