### PR TITLE
Align legacy CSS color aliases with canonical tokens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,11 @@
   <title>EZ Quiz</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" />
-  <script src="js/theme-preload.js?v=1.5.23"></script>
-  <link rel="stylesheet" href="styles.css?v=1.5.23" />
-  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.23">
-  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.23">
-  <script src="js/boot-beta.js?v=1.5.23"></script>
+  <script src="js/theme-preload.js?v=1.5.24"></script>
+  <link rel="stylesheet" href="styles.css?v=1.5.24" />
+  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.24">
+  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.24">
+  <script src="js/boot-beta.js?v=1.5.24"></script>
 </head>
 <body>
   <header class="site-header" role="banner">
@@ -641,10 +641,10 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   
 
-  <script type="module" src="js/main.js?v=1.5.23"></script>
-  <script type="module" src="js/auto-refresh.js?v=1.5.23"></script>
-  <script type="module" src="js/patches.js?v=1.5.23"></script>
-  <script type="module" src="js/editor.gui.js?v=1.5.23"></script>
+  <script type="module" src="js/main.js?v=1.5.24"></script>
+  <script type="module" src="js/auto-refresh.js?v=1.5.24"></script>
+  <script type="module" src="js/patches.js?v=1.5.24"></script>
+  <script type="module" src="js/editor.gui.js?v=1.5.24"></script>
 
   <!-- Floating actions: Feedback + Coffee -->
   <div id="floatingActions" class="fab-stack" aria-label="Quick actions">

--- a/public/js/editor.gui.js
+++ b/public/js/editor.gui.js
@@ -1,6 +1,6 @@
 // Interactive Editor (beta) — rebuilt v2
 // Simple, robust, no global delegation; uses pointerdown to beat Options capture
-import { runParseFlow } from './generator.js?v=1.5.23';
+import { runParseFlow } from './generator.js?v=1.5.24';
 
 const IE2 = (()=>{
   const SKEY = 'ezq.ie.v2.on';

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -1,12 +1,12 @@
 import { S } from './state.js';
 import { $, byQSA, mmSsToMs, clampCount, getMaxQuestions } from './utils.js';
 import { parseEditorInput } from './parser.js';
-import { generateWithAI } from './api.js?v=1.5.23';
+import { generateWithAI } from './api.js?v=1.5.24';
 import { ImportController } from './import-controller.js';
 import { sniffFileKind, isSupportedImportKind } from './file-type-validation.js';
 import { attachDragDrop } from './drag-drop.js';
-import { announce } from './a11y-announcer.js?v=1.5.23';
-import { buildGeneratorPayload } from './generator-payload.js?v=1.5.23';
+import { announce } from './a11y-announcer.js?v=1.5.24';
+import { buildGeneratorPayload } from './generator-payload.js?v=1.5.24';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,7 +2,7 @@ import { S } from './state.js';
 import { $, byQSA, showUpdateBannerIfReady } from './utils.js';
 import { loadSettingsFromStorage, applyTheme, reflectSettingsIntoUI, wireSettingsPanel } from './settings.js';
 import { wireModals } from './modals.js';
-import { wireGenerator } from './generator.js?v=1.5.23';
+import { wireGenerator } from './generator.js?v=1.5.24';
 import { setMode, beginQuiz, renderCurrentQuestion, updateNavButtons, updateProgress, wireQuizControls, wireResultsControls, pauseTimerIfQuiz, resumeTimerIfQuiz, syncSettingsFromUI } from './quiz.js';
 import { has as hasFlag, hasCookie as hasCookieFlag } from './flags.js';
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,22 +2,22 @@
 :root {
   --brand:#FFC94A;
   --brand-press:#E5B03F;
-  --c-accent:#6270f3;
-  --c-accent-active:#4f5be9;
-  --c-page:#0d111a;
-  --c-surface-1:#151b27;
-  --c-surface-2:#1b2232;
-  --c-surface-3:#212a3d;
-  --c-input:#111623;
-  --c-border-weak:rgba(255,255,255,0.10);
-  --c-border-strong:rgba(255,255,255,0.18);
-  --c-text:#e9eef6;
-  --c-text-muted:#a5aec2;
-  --c-danger:#ff5d6c;
-  --c-danger-active:#d83545;
-  --c-success:#34d399;
-  --c-success-active:#16a34a;
-  --c-focus-ring:rgba(113,140,255,0.40);
+  --c-accent:var(--accent);
+  --c-accent-active:var(--accent-press);
+  --c-page:var(--surface-0);
+  --c-surface-1:var(--surface-1);
+  --c-surface-2:var(--surface-2);
+  --c-surface-3:color-mix(in oklab, var(--surface-2) 85%, var(--text) 15%);
+  --c-input:color-mix(in oklab, var(--surface-0) 90%, var(--text) 10%);
+  --c-border-weak:var(--hairline);
+  --c-border-strong:color-mix(in oklab, var(--hairline) 70%, var(--text) 30%);
+  --c-text:var(--text);
+  --c-text-muted:var(--muted);
+  --c-danger:var(--negative);
+  --c-danger-active:var(--negative-strong);
+  --c-success:var(--positive);
+  --c-success-active:var(--positive-strong);
+  --c-focus-ring:var(--focus-outer);
   --sp-0:0;
   --sp-1:4px;
   --sp-2:8px;
@@ -77,22 +77,22 @@
   --adv-box-min: 260px;
 }
 :root[data-theme="light"] {
-  --c-page:#f6f8fb;
-  --c-surface-1:#ffffff;
-  --c-surface-2:#eef2f9;
-  --c-surface-3:#e0e7f5;
-  --c-input:#e9edf7;
-  --c-border-weak:rgba(15,23,42,0.12);
-  --c-border-strong:rgba(15,23,42,0.18);
-  --c-text:#0d1117;
-  --c-text-muted:#4b5565;
-  --c-accent:#5261ee;
-  --c-accent-active:#4251d8;
-  --c-success:#16a34a;
-  --c-success-active:#0f7a32;
-  --c-danger:#cf2e3a;
-  --c-danger-active:#a3202a;
-  --c-focus-ring:rgba(113,140,255,0.28);
+  --c-page:var(--surface-0);
+  --c-surface-1:var(--surface-1);
+  --c-surface-2:var(--surface-2);
+  --c-surface-3:color-mix(in oklab, var(--surface-2) 85%, var(--text) 15%);
+  --c-input:color-mix(in oklab, var(--surface-0) 90%, var(--text) 10%);
+  --c-border-weak:var(--hairline);
+  --c-border-strong:color-mix(in oklab, var(--hairline) 70%, var(--text) 30%);
+  --c-text:var(--text);
+  --c-text-muted:var(--muted);
+  --c-accent:var(--accent);
+  --c-accent-active:var(--accent-press);
+  --c-success:var(--positive);
+  --c-success-active:var(--positive-strong);
+  --c-danger:var(--negative);
+  --c-danger-active:var(--negative-strong);
+  --c-focus-ring:var(--focus-outer);
   color-scheme: light;
 }
 /* Soft Outlines visual variant — lighter borders, softer focus, gentler shadow */

--- a/public/styles.tokens.css
+++ b/public/styles.tokens.css
@@ -46,6 +46,12 @@
   --theme-dark-contrast:  black;
   --theme-dark-elev-1: 0 2px 10px rgba(0,0,0,.45);
   --theme-dark-elev-2: 0 12px 42px rgba(0,0,0,.6);
+  --theme-dark-accent-press: color-mix(in oklab, var(--theme-dark-accent) 86%, black 14%);
+  --theme-dark-positive: #34d399;
+  --theme-dark-positive-strong: #16a34a;
+  --theme-dark-negative: #ff5d6c;
+  --theme-dark-negative-strong: #d83545;
+  --theme-dark-focus-outer: color-mix(in oklab, var(--theme-dark-accent) 52%, transparent);
 
   --theme-light-surface-0: oklch(0.98 0.01 250);
   --theme-light-surface-1: oklch(0.97 0.01 250);
@@ -57,6 +63,12 @@
   --theme-light-contrast:  white;
   --theme-light-elev-1: 0 2px 8px rgba(0,0,0,.08);
   --theme-light-elev-2: 0 10px 36px rgba(0,0,0,.16);
+  --theme-light-accent-press: color-mix(in oklab, var(--theme-light-accent) 84%, black 16%);
+  --theme-light-positive: #16a34a;
+  --theme-light-positive-strong: #0f7a32;
+  --theme-light-negative: #cf2e3a;
+  --theme-light-negative-strong: #a3202a;
+  --theme-light-focus-outer: color-mix(in oklab, var(--theme-light-accent) 36%, transparent);
 
   /* Default to dark theme until data-theme applies */
   color-scheme: dark;
@@ -70,6 +82,12 @@
   --theme-accent-contrast: var(--theme-dark-contrast);
   --theme-elev-1: var(--theme-dark-elev-1);
   --theme-elev-2: var(--theme-dark-elev-2);
+  --theme-accent-press: var(--theme-dark-accent-press);
+  --theme-positive: var(--theme-dark-positive);
+  --theme-positive-strong: var(--theme-dark-positive-strong);
+  --theme-negative: var(--theme-dark-negative);
+  --theme-negative-strong: var(--theme-dark-negative-strong);
+  --theme-focus-outer: var(--theme-dark-focus-outer);
 
   /* Public tokens consume the currently active theme aliases */
   --surface-0: var(--theme-surface-0);
@@ -82,6 +100,12 @@
   --accent-contrast: var(--theme-accent-contrast);
   --elev-1: var(--theme-elev-1);
   --elev-2: var(--theme-elev-2);
+  --accent-press: var(--theme-accent-press);
+  --positive: var(--theme-positive);
+  --positive-strong: var(--theme-positive-strong);
+  --negative: var(--theme-negative);
+  --negative-strong: var(--theme-negative-strong);
+  --focus-outer: var(--theme-focus-outer);
 }
 
 :root[data-theme="light"] {
@@ -96,6 +120,12 @@
   --theme-accent-contrast: var(--theme-light-contrast);
   --theme-elev-1: var(--theme-light-elev-1);
   --theme-elev-2: var(--theme-light-elev-2);
+  --theme-accent-press: var(--theme-light-accent-press);
+  --theme-positive: var(--theme-light-positive);
+  --theme-positive-strong: var(--theme-light-positive-strong);
+  --theme-negative: var(--theme-light-negative);
+  --theme-negative-strong: var(--theme-light-negative-strong);
+  --theme-focus-outer: var(--theme-light-focus-outer);
 }
 
 :root[data-theme="dark"] {
@@ -110,6 +140,12 @@
   --theme-accent-contrast: var(--theme-dark-contrast);
   --theme-elev-1: var(--theme-dark-elev-1);
   --theme-elev-2: var(--theme-dark-elev-2);
+  --theme-accent-press: var(--theme-dark-accent-press);
+  --theme-positive: var(--theme-dark-positive);
+  --theme-positive-strong: var(--theme-dark-positive-strong);
+  --theme-negative: var(--theme-dark-negative);
+  --theme-negative-strong: var(--theme-dark-negative-strong);
+  --theme-focus-outer: var(--theme-dark-focus-outer);
 }
 
 @media (prefers-color-scheme: light) {
@@ -125,6 +161,12 @@
     --theme-accent-contrast: var(--theme-light-contrast);
     --theme-elev-1: var(--theme-light-elev-1);
     --theme-elev-2: var(--theme-light-elev-2);
+    --theme-accent-press: var(--theme-light-accent-press);
+    --theme-positive: var(--theme-light-positive);
+    --theme-positive-strong: var(--theme-light-positive-strong);
+    --theme-negative: var(--theme-light-negative);
+    --theme-negative-strong: var(--theme-light-negative-strong);
+    --theme-focus-outer: var(--theme-light-focus-outer);
   }
 }
 
@@ -141,5 +183,11 @@
     --theme-accent-contrast: var(--theme-dark-contrast);
     --theme-elev-1: var(--theme-dark-elev-1);
     --theme-elev-2: var(--theme-dark-elev-2);
+    --theme-accent-press: var(--theme-dark-accent-press);
+    --theme-positive: var(--theme-dark-positive);
+    --theme-positive-strong: var(--theme-dark-positive-strong);
+    --theme-negative: var(--theme-dark-negative);
+    --theme-negative-strong: var(--theme-dark-negative-strong);
+    --theme-focus-outer: var(--theme-dark-focus-outer);
   }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,8 +8,8 @@
  * page for navigation requests when offline.
  */
 
-const ASSET_VERSION = '1.5.23';
-const CACHE_NAME = 'ezq-v1207';
+const ASSET_VERSION = '1.5.24';
+const CACHE_NAME = 'ezq-v1208';
 const PRECACHE_URLS = [
   '/index.html',
   '/styles.css?v=' + ASSET_VERSION,

--- a/tests/beta-gating.test.js
+++ b/tests/beta-gating.test.js
@@ -2,6 +2,12 @@
 
 describe('beta gating helper', () => {
   afterEach(() => {
+    if (typeof document !== 'undefined' && document?.body) {
+      document.body.removeAttribute?.('data-beta');
+      if (document.body.dataset) {
+        delete document.body.dataset.beta;
+      }
+    }
     delete global.document;
   });
 
@@ -12,7 +18,11 @@ describe('beta gating helper', () => {
 
   test('returns true when data-beta attribute is present', async () => {
     const { isBetaEnabled } = await import('../public/js/beta.mjs');
-    global.document = { body: { hasAttribute: () => false, dataset: { beta: '' } } };
+    if (typeof document !== 'undefined' && document?.body) {
+      document.body.setAttribute?.('data-beta', '');
+    } else {
+      global.document = { body: { hasAttribute: () => true, dataset: { beta: '' } } };
+    }
     expect(isBetaEnabled({ betaEnabled: false })).toBe(true);
   });
 

--- a/tests/clampCount.test.js
+++ b/tests/clampCount.test.js
@@ -5,17 +5,32 @@ const { loadBrowserModule } = require('./utils');
 describe('clampCount', () => {
   let clampCount;
   let getMaxQuestions;
+  let originalWindow;
 
   beforeAll(() => {
+    originalWindow = global.window;
     ({ clampCount, getMaxQuestions } = loadBrowserModule('public/js/utils.js', ['clampCount', 'getMaxQuestions']));
   });
 
   beforeEach(() => {
-    global.window = { __EZQ__: { MAX_QUESTIONS: 30 } };
+    if (originalWindow) {
+      global.window = originalWindow;
+    }
+    if (!global.window) {
+      global.window = {};
+    }
+    global.window.__EZQ__ = { MAX_QUESTIONS: 30 };
   });
 
   afterEach(() => {
-    delete global.window;
+    if (global.window && global.window.__EZQ__) {
+      delete global.window.__EZQ__;
+    }
+    if (originalWindow) {
+      global.window = originalWindow;
+    } else {
+      delete global.window;
+    }
   });
 
   test('returns fallback when input is empty', () => {

--- a/tests/css-tokens.test.js
+++ b/tests/css-tokens.test.js
@@ -8,6 +8,9 @@ describe('public/styles.css core tokens', () => {
   const tokenAssertions = [
     ['--field', /--field\s*:\s*var\(--c-input\)/],
     ['--text', /--text\s*:\s*var\(--c-text\)/],
+    ['--c-page', /--c-page\s*:\s*var\(--surface-0\)/],
+    ['--c-accent', /--c-accent\s*:\s*var\(--accent\)/],
+    ['--c-success', /--c-success\s*:\s*var\(--positive\)/],
     ['--radius-card', /--radius-card\s*:\s*calc\(/],
     ['--shadow-card', /--shadow-card\s*:\s*0\s+4px\s+14px/],
   ];
@@ -20,7 +23,6 @@ describe('public/styles.css core tokens', () => {
     expect(css).toMatch(/:root\s*\{/);
     expect(css).toMatch(/:root\[data-theme="light"\]\s*\{/);
     expect(css).toMatch(/:root\[data-theme="dark"\]\s*\{/);
-    expect(css).toMatch(/--c-page:#f6f8fb;/);
-    expect(css).toMatch(/--c-text:#0d1117;/);
+    expect(css).toMatch(/:root\[data-theme="light"\][^}]*--c-accent-active:var\(--accent-press\)/);
   });
 });


### PR DESCRIPTION
## Summary
- map the root `--c-*` tokens in `public/styles.css` to the canonical palette so both dark and light themes consume shared aliases
- extend `public/styles.tokens.css` with pressed/accent, semantic status, and focus ring tokens that back the legacy aliases
- refresh the CSS token assertion and helper unit tests to reference the new aliases and stabilise window/document stubs in jsdom

## Testing
- npm test
- npm run test:css *(fails: script not defined)*
- npm run ui:check *(fails: Chromium missing libatk-1.0.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116e5c3b0483299585c71b253ee374)