### PR TITLE
Adjust Scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,6 +11,8 @@ jobs:
   analysis:
     permissions:
       contents: read
+      pull-requests: read
+      issues: read
       security-events: write
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant the Scorecard workflow read access to pull requests and issues so it can inspect reviews while keeping other scopes minimal

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124be03f6c83299fad9d82ed1b0c72)