### PR TITLE
Adjust publish workflow PR body indentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,11 +163,11 @@ jobs:
           set -euo pipefail
           cd public-repo
           PR_TITLE="Mirror: ${GITHUB_SHA:0:12} → main"
-          PR_BODY=$(cat <<EOF
-Automated mirror update from \`seanyates76/Ez-Quiz-Dev\`.
-
-- Source commit: ${GITHUB_SHA}
-- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          PR_BODY=$(cat <<-'EOF'
+	Automated mirror update from \`seanyates76/Ez-Quiz-Dev\`.
+	
+	- Source commit: ${GITHUB_SHA}
+	- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 EOF
           )
           if gh pr view --repo seanyates76/Ez-Quiz-App --head "$SYNC_BRANCH" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- switch the publish workflow PR body assignment to a tab-indented heredoc so the script stays aligned within the run block

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c6089dc083299acbdbf78ef336d0)