### PR TITLE
Restore Scorecard result publishing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,9 +19,13 @@ jobs:
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          results_file: results.json
-          results_format: json
+          results_file: results.sarif
+          results_format: sarif
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_results: false
-          upload_results: false
+          publish_results: true
+          upload_results: true
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
 


### PR DESCRIPTION
## Summary
- switch the Scorecard workflow back to SARIF output and re-enable publishing/uploading so the metrics are reported to Scorecards and GitHub code scanning
- add back the SARIF upload step so code scanning ingests the scheduled results

## Testing
- Not run (workflow-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f08c3a188329a6b021a93adef534)