### PR TITLE
Grant Scorecard workflow permissions for SARIF upload

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,8 @@ jobs:
       issues: read
       pull-requests: read
       actions: read
+      security-events: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Run OpenSSF Scorecard


### PR DESCRIPTION
## Summary
- grant the workflow the `security-events: write` and `id-token: write` permissions needed for uploading Scorecard SARIF results

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161111fb108329bf5fff84dd3b4dd1)