### PR TITLE
Add optional debug log hook

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -6,6 +6,14 @@ import { wireGenerator } from './generator.js?v=1.5.27';
 import { setMode, beginQuiz, renderCurrentQuestion, updateNavButtons, updateProgress, wireQuizControls, wireResultsControls, pauseTimerIfQuiz, resumeTimerIfQuiz, syncSettingsFromUI } from './quiz.js';
 import { has as hasFlag, hasCookie as hasCookieFlag } from './flags.js';
 
+function debugLog(message){
+  try {
+    if (localStorage.getItem('EZQ_DEBUG')) {
+      console.debug('[ezq:dev]', message);
+    }
+  } catch {}
+}
+
 function getEls(){
   return {
     themeRadios: byQSA('input[name="theme"]'),
@@ -20,6 +28,7 @@ function getEls(){
 }
 
 function init(){
+  debugLog('main:init begin');
   // Measure header height for light theme brand placement
   (function headerMetrics(){
     function updateHeaderVars(){


### PR DESCRIPTION
## Summary
- add a small `debugLog` helper in `public/js/main.js` that only emits console output when `EZQ_DEBUG` is set in localStorage
- log when `main` initialization begins to make local debugging easier without affecting production users

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691661789a2c8329b79226c05aed8394)