### PR TITLE
Skip optional npm packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - name: Install
-        run: npm ci
+        run: npm ci --no-optional
       - name: Lint
         run: npm run lint --if-present
       - name: Test


### PR DESCRIPTION
## Summary
- configure the CI install step to run `npm ci --no-optional` so Linux runners skip platform-specific optional packages

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e085bca08329a9705865067971f0)