### PR TITLE
ci(publish): preserve repo-specific files excluded from mirror

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,8 +138,10 @@ jobs:
             else
               git checkout -B "$SYNC_BRANCH"
             fi
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-            rsync -a --delete --exclude=.git/ ../filtered/ ./
+            # Preserve repo-specific files that are intentionally excluded from the mirror
+            # (for example the production README). We still delete mirrored files that no
+            # longer exist upstream, but we do not wipe the destination before syncing.
+            rsync -a --delete --exclude=.git/ --exclude-from=../.publicignore ../filtered/ ./
             git add -A
             if git diff --cached --quiet; then
               echo "No changes to publish."


### PR DESCRIPTION
## Summary
- preserve repo-specific files that are intentionally excluded from the mirror export

## Why
The mirror workflow currently wipes the destination tree before syncing filtered contents back in. That causes excluded production-side files like `README.md` to be deleted instead of preserved, which led to the current `mirror/main` conflict in `Ez-Quiz-App`.

## Fix
Stop wiping the destination tree. Instead, sync with `rsync --delete` while also honoring `.publicignore` during the destination update.

This keeps mirrored files in sync while preserving intentionally repo-specific files downstream.
