### PR TITLE
ci(publish): add explicit preserve list for mirror-specific files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,8 +138,10 @@ jobs:
             else
               git checkout -B "$SYNC_BRANCH"
             fi
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-            rsync -a --delete --exclude=.git/ ../filtered/ ./
+            # Preserve repo-specific files that are intentionally excluded from the mirror
+            # (for example the production README). We still delete mirrored files that no
+            # longer exist upstream, but we do not wipe the destination before syncing.
+            rsync -a --delete --exclude=.git/ --exclude-from=../.publicignore ../filtered/ ./
             git add -A
             if git diff --cached --quiet; then
               echo "No changes to publish."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,10 +138,13 @@ jobs:
             else
               git checkout -B "$SYNC_BRANCH"
             fi
-            # Preserve repo-specific files that are intentionally excluded from the mirror
-            # (for example the production README). We still delete mirrored files that no
-            # longer exist upstream, but we do not wipe the destination before syncing.
-            rsync -a --delete --exclude=.git/ --exclude-from=../.publicignore ../filtered/ ./
+            # Preserve repo-specific downstream files (for example the production README)
+            # without turning every ignored source path into permanent mirror residue.
+            PRESERVE_ARGS=()
+            if [ -f ../.publicpreserve ]; then
+              PRESERVE_ARGS+=(--exclude-from=../.publicpreserve)
+            fi
+            rsync -a --delete --exclude=.git/ "${PRESERVE_ARGS[@]}" ../filtered/ ./
             git add -A
             if git diff --cached --quiet; then
               echo "No changes to publish."

--- a/.publicignore
+++ b/.publicignore
@@ -5,6 +5,7 @@
 .git/
 .github/workflows/
 .gitignore
+.publicpreserve
 
 # Local artifacts
 node_modules/
@@ -20,7 +21,6 @@ issues/
 tests/
 scripts/
 agents.md
-README.md
 
 # Tests and internal tooling (uncomment if desired)
 # tests/

--- a/.publicpreserve
+++ b/.publicpreserve
@@ -1,0 +1,4 @@
+# Files that should remain repo-specific in the production mirror
+# These are excluded only from the destination sync pass, so the mirror
+# will not overwrite or delete the downstream copy.
+README.md


### PR DESCRIPTION
## Summary
- add `.publicpreserve` for downstream repo-specific files
- preserve only explicitly listed files during mirror sync
- keep `.publicignore` focused on paths that should not be published

## Why
Using `.publicignore` alone for same-name files like `README.md` creates the wrong tradeoff:
- either the mirror deletes repo-specific downstream files
- or ignored files linger downstream forever

This PR separates those concerns.

## Design
- `.publicignore` = do not publish from the development repo
- `.publicpreserve` = do not overwrite/delete the downstream copy during mirror sync

Current preserved file:
- `README.md`
