### PR TITLE
ci(publish): use mirror staging branch for public repo sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
         - name: Sync and push staging branch
           id: sync
           env:
-            SYNC_BRANCH: mirror/main
+            SYNC_BRANCH: mirror/staging
             HAS_PAT: ${{ steps.detect.outputs.has_pat }}
             HAS_DEPLOY_KEY: ${{ steps.detect.outputs.has_deploy_key }}
           run: |
@@ -179,7 +179,7 @@ jobs:
           if: ${{ steps.detect.outputs.has_pat == 'true' && steps.sync.outputs.has_changes == 'true' }}
           env:
             GH_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
-            SYNC_BRANCH: mirror/main
+            SYNC_BRANCH: mirror/staging
           run: |
             set -euo pipefail
             cd public-repo


### PR DESCRIPTION
## Summary
- switch the public mirror workflow from `mirror/main` to `mirror/staging`

## Why
The production repo ruleset correctly blocks direct pushes that look like mainline changes. The mirror workflow needs a pushable automation branch so it can open/update a PR into `main`.

Using `mirror/staging` makes that intent explicit and avoids overloading `mirror/main` as if it were a protected branch.

## Notes
- `main` remains the protected merge target
- the mirror workflow still opens a PR into `main`
- this is a workflow/branching fix, not an app-behavior change
