### PR TITLE
fix: selectively mirror public-safe workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,36 @@ jobs:
             RSYNC_EXCLUDES+=("--exclude-from=.publicignore")
             rsync -a --delete "${RSYNC_EXCLUDES[@]}" ./ ./filtered/
 
+            # Allow a small, explicit set of shared public-safe workflows to flow
+            # downstream even though `.publicignore` blocks the workflow directory
+            # by default. This keeps dev-only automation private while still
+            # satisfying required public checks such as CodeQL.
+            if [ -f .publicworkflows ]; then
+              mkdir -p filtered/.github/workflows
+              while IFS= read -r workflow_path; do
+                workflow_path="${workflow_path#./}"
+                case "$workflow_path" in
+                  ''|'#'*)
+                    continue
+                    ;;
+                esac
+                if [ ! -f "$workflow_path" ]; then
+                  echo "Shared public workflow '$workflow_path' is listed in .publicworkflows but missing." >&2
+                  exit 1
+                fi
+                case "$workflow_path" in
+                  .github/workflows/*)
+                    mkdir -p "filtered/$(dirname "$workflow_path")"
+                    cp "$workflow_path" "filtered/$workflow_path"
+                    ;;
+                  *)
+                    echo "Shared public workflow entries must stay under .github/workflows/: $workflow_path" >&2
+                    exit 1
+                    ;;
+                esac
+              done < <(awk '!/^[[:space:]]*(#|$)/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print }' .publicworkflows)
+            fi
+
         - name: Clone public repo
           env:
             HAS_PAT: ${{ steps.detect.outputs.has_pat }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,31 +90,11 @@ jobs:
             # downstream even though `.publicignore` blocks the workflow directory
             # by default. This keeps dev-only automation private while still
             # satisfying required public checks such as CodeQL.
-            if [ -f .publicworkflows ]; then
-              mkdir -p filtered/.github/workflows
-              while IFS= read -r workflow_path; do
-                workflow_path="${workflow_path#./}"
-                case "$workflow_path" in
-                  ''|'#'*)
-                    continue
-                    ;;
-                esac
-                if [ ! -f "$workflow_path" ]; then
-                  echo "Shared public workflow '$workflow_path' is listed in .publicworkflows but missing." >&2
-                  exit 1
-                fi
-                case "$workflow_path" in
-                  .github/workflows/*)
-                    mkdir -p "filtered/$(dirname "$workflow_path")"
-                    cp "$workflow_path" "filtered/$workflow_path"
-                    ;;
-                  *)
-                    echo "Shared public workflow entries must stay under .github/workflows/: $workflow_path" >&2
-                    exit 1
-                    ;;
-                esac
-              done < <(awk '!/^[[:space:]]*(#|$)/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print }' .publicworkflows)
-            fi
+            mkdir -p filtered/.github/workflows
+            while IFS= read -r workflow_path; do
+              mkdir -p "filtered/$(dirname "$workflow_path")"
+              cp "$workflow_path" "filtered/$workflow_path"
+            done < <(files/scripts/public-workflows.sh "$PWD")
 
         - name: Clone public repo
           env:

--- a/.publicworkflows
+++ b/.publicworkflows
@@ -1,0 +1,4 @@
+# Public-safe workflows that should be copied into the production mirror.
+# Keep this list tiny and explicit.
+
+.github/workflows/codeql.yml

--- a/files/scripts/mirror.sh
+++ b/files/scripts/mirror.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR/../.." rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
 PUBLIC_GH_SSH="${PUBLIC_GH_SSH:-git@github.com:seanyates76/Ez-Quiz-App.git}"
-PUB_DIR="${PUB_DIR:-.mirror-push}"
+PUB_DIR_INPUT="${PUB_DIR:-.mirror-push}"
+case "$PUB_DIR_INPUT" in
+  /*)
+    PUB_DIR="$PUB_DIR_INPUT"
+    ;;
+  *)
+    PUB_DIR="$REPO_ROOT/$PUB_DIR_INPUT"
+    ;;
+esac
 
 # 1) Build a clean export of the current tree
 rm -rf "$PUB_DIR"
@@ -14,31 +27,11 @@ git archive --format=tar HEAD | tar -x -C "$PUB_DIR"
 
 # 2b) Keep workflow export explicit. The repo excludes all workflows from the
 # public mirror by default; copy back only the public-safe shared ones.
-if [ -f .publicworkflows ]; then
-  rm -rf "$PUB_DIR/.github/workflows"
-  while IFS= read -r workflow_path; do
-    workflow_path="${workflow_path#./}"
-    case "$workflow_path" in
-      ''|'#'*)
-        continue
-        ;;
-    esac
-    if [ ! -f "$workflow_path" ]; then
-      echo "Shared public workflow '$workflow_path' is listed in .publicworkflows but missing." >&2
-      exit 1
-    fi
-    case "$workflow_path" in
-      .github/workflows/*)
-        mkdir -p "$PUB_DIR/$(dirname "$workflow_path")"
-        cp "$workflow_path" "$PUB_DIR/$workflow_path"
-        ;;
-      *)
-        echo "Shared public workflow entries must stay under .github/workflows/: $workflow_path" >&2
-        exit 1
-        ;;
-    esac
-  done < <(awk '!/^[[:space:]]*(#|$)/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print }' .publicworkflows)
-fi
+rm -rf "$PUB_DIR/.github/workflows"
+while IFS= read -r workflow_path; do
+  mkdir -p "$PUB_DIR/$(dirname "$workflow_path")"
+  cp "$workflow_path" "$PUB_DIR/$workflow_path"
+done < <("$SCRIPT_DIR/public-workflows.sh" "$REPO_ROOT")
 
 # 3) Initialize mirror repo and push force to main
 pushd "$PUB_DIR" >/dev/null

--- a/files/scripts/mirror.sh
+++ b/files/scripts/mirror.sh
@@ -12,6 +12,34 @@ git archive --format=tar HEAD | tar -x -C "$PUB_DIR"
 # Uncomment to exclude private stuff from the mirror
 # rm -rf "$PUB_DIR/ops" "$PUB_DIR/notes" "$PUB_DIR/.github/ISSUE_TEMPLATE/internal"
 
+# 2b) Keep workflow export explicit. The repo excludes all workflows from the
+# public mirror by default; copy back only the public-safe shared ones.
+if [ -f .publicworkflows ]; then
+  rm -rf "$PUB_DIR/.github/workflows"
+  while IFS= read -r workflow_path; do
+    workflow_path="${workflow_path#./}"
+    case "$workflow_path" in
+      ''|'#'*)
+        continue
+        ;;
+    esac
+    if [ ! -f "$workflow_path" ]; then
+      echo "Shared public workflow '$workflow_path' is listed in .publicworkflows but missing." >&2
+      exit 1
+    fi
+    case "$workflow_path" in
+      .github/workflows/*)
+        mkdir -p "$PUB_DIR/$(dirname "$workflow_path")"
+        cp "$workflow_path" "$PUB_DIR/$workflow_path"
+        ;;
+      *)
+        echo "Shared public workflow entries must stay under .github/workflows/: $workflow_path" >&2
+        exit 1
+        ;;
+    esac
+  done < <(awk '!/^[[:space:]]*(#|$)/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print }' .publicworkflows)
+fi
+
 # 3) Initialize mirror repo and push force to main
 pushd "$PUB_DIR" >/dev/null
 git init

--- a/files/scripts/public-workflows.sh
+++ b/files/scripts/public-workflows.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+repo_root="$(cd "$repo_root" && pwd)"
+publicworkflows_file="$repo_root/.publicworkflows"
+workflows_root="$repo_root/.github/workflows"
+
+if [ ! -f "$publicworkflows_file" ]; then
+  echo "Missing .publicworkflows. Refusing to mirror workflows without an explicit allowlist." >&2
+  exit 1
+fi
+
+if [ ! -d "$workflows_root" ]; then
+  echo "Missing .github/workflows directory under repo root: $workflows_root" >&2
+  exit 1
+fi
+
+found_any=false
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+  workflow_path="$(printf '%s' "$raw_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  case "$workflow_path" in
+    ''|'#'*)
+      continue
+      ;;
+  esac
+
+  case "$workflow_path" in
+    /*)
+      echo "Shared public workflow entries must be repo-relative, not absolute: $workflow_path" >&2
+      exit 1
+      ;;
+  esac
+
+  workflow_path="${workflow_path#./}"
+
+  case "$workflow_path" in
+    *".."*)
+      echo "Shared public workflow entries must not contain '..': $workflow_path" >&2
+      exit 1
+      ;;
+    .github/workflows/*)
+      ;;
+    *)
+      echo "Shared public workflow entries must stay under .github/workflows/: $workflow_path" >&2
+      exit 1
+      ;;
+  esac
+
+  source_path="$repo_root/$workflow_path"
+  if [ ! -f "$source_path" ]; then
+    echo "Shared public workflow '$workflow_path' is listed in .publicworkflows but missing." >&2
+    exit 1
+  fi
+
+  resolved_source="$(realpath "$source_path")"
+  case "$resolved_source" in
+    "$workflows_root"/*)
+      ;;
+    *)
+      echo "Resolved workflow path escapes .github/workflows/: $workflow_path -> $resolved_source" >&2
+      exit 1
+      ;;
+  esac
+
+  found_any=true
+  printf '%s\n' "${resolved_source#$repo_root/}"
+done < "$publicworkflows_file"
+
+if [ "$found_any" != true ]; then
+  echo ".publicworkflows must list at least one public-safe workflow. Refusing to mirror an implicit default." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- keep `.github/workflows/` excluded from the public mirror by default
- add a tiny allowlist mechanism for **public-safe** workflows
- currently export only the public `codeql.yml` workflow into the mirrored repo

## Why
The public repo PR path was blocked on a required `CodeQL` check that never reported, because the mirror flow excluded all workflows and the mirrored branch did not contain the workflow needed to emit that status.

This change stabilizes the mirror architecture without leaking dev-only workflows into the public repo.

## What changed
- added `.publicworkflows`
- updated `.github/workflows/publish.yml`
- updated `files/scripts/mirror.sh`

## Result
- Dev-only workflows remain private by default
- public-safe workflows can be selectively mirrored
- the public mirror can carry the CodeQL workflow needed for required checks
