### PR TITLE
fix: update mirror PR detection and precache imports

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,8 +202,8 @@ jobs:
               "${GITHUB_SERVER_URL}" \
               "${GITHUB_REPOSITORY}" \
               "${GITHUB_RUN_ID}"
-            if gh pr view --repo seanyates76/Ez-Quiz-App --head "$SYNC_BRANCH" >/dev/null 2>&1; then
-              PR_NUMBER=$(gh pr view --repo seanyates76/Ez-Quiz-App --head "$SYNC_BRANCH" --json number -q '.number')
+            PR_NUMBER=$(gh pr list --repo seanyates76/Ez-Quiz-App --state open --head "$SYNC_BRANCH" --json number --jq '.[0].number')
+            if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
               gh pr edit "$PR_NUMBER" --repo seanyates76/Ez-Quiz-App --title "$PR_TITLE" --body "$PR_BODY"
             else
               gh pr create --repo seanyates76/Ez-Quiz-App --base main --head "$SYNC_BRANCH" --title "$PR_TITLE" --body "$PR_BODY"

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,11 @@
   <title>EZ Quiz</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" />
-  <script src="js/theme-preload.js?v=1.5.27"></script>
-  <link rel="stylesheet" href="styles.css?v=1.5.27" />
-  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.27">
-  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.27">
-  <script src="js/boot-beta.js?v=1.5.27"></script>
+  <script src="js/theme-preload.js?v=1.5.28"></script>
+  <link rel="stylesheet" href="styles.css?v=1.5.28" />
+  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.28">
+  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.28">
+  <script src="js/boot-beta.js?v=1.5.28"></script>
 </head>
 <body>
   <header class="site-header" role="banner">
@@ -640,10 +640,10 @@ MT|Prompt.|1) L1;2) L2|A) R1;B) R2|1-A,2-B</pre>
 
   
 
-  <script type="module" src="js/main.js?v=1.5.27"></script>
-  <script type="module" src="js/auto-refresh.js?v=1.5.27"></script>
-  <script type="module" src="js/patches.js?v=1.5.27"></script>
-  <script type="module" src="js/editor.gui.js?v=1.5.27"></script>
+  <script type="module" src="js/main.js?v=1.5.28"></script>
+  <script type="module" src="js/auto-refresh.js?v=1.5.28"></script>
+  <script type="module" src="js/patches.js?v=1.5.28"></script>
+  <script type="module" src="js/editor.gui.js?v=1.5.28"></script>
 
   <!-- Floating actions: Feedback + Coffee -->
   <div id="floatingActions" class="fab-stack" aria-label="Quick actions">

--- a/public/js/editor.gui.js
+++ b/public/js/editor.gui.js
@@ -1,6 +1,6 @@
 // Interactive Editor (beta) — rebuilt v2
 // Simple, robust, no global delegation; uses pointerdown to beat Options capture
-import { runParseFlow } from './generator.js?v=1.5.27';
+import { runParseFlow } from './generator.js?v=1.5.28';
 
 const IE2 = (()=>{
   const SKEY = 'ezq.ie.v2.on';

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -1,13 +1,13 @@
 import { S } from './state.js';
 import { $, byQSA, mmSsToMs, clampCount, getMaxQuestions } from './utils.js';
 import { parseEditorInput } from './parser.js';
-import { generateWithAI } from './api.js?v=1.5.27';
+import { generateWithAI } from './api.js?v=1.5.28';
 import { ImportController } from './import-controller.js';
 import { sniffFileKind, isSupportedImportKind, hasImportMetadataMismatch } from './file-type-validation.js';
 import { validateMediaImportSize } from './media-import-constraints.js';
 import { attachDragDrop } from './drag-drop.js';
-import { announce } from './a11y-announcer.js?v=1.5.27';
-import { buildGeneratorPayload } from './generator-payload.js?v=1.5.27';
+import { announce } from './a11y-announcer.js?v=1.5.28';
+import { buildGeneratorPayload } from './generator-payload.js?v=1.5.28';
 import { showVeil, hideVeil, MESSAGES } from './veil.js';
 import { applyTheme, saveSettingsToStorage, getShowQuizEditorPreference } from './settings.js';
 import { STORAGE_KEYS } from './state.js';

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,7 +2,7 @@ import { S } from './state.js';
 import { $, byQSA, showUpdateBannerIfReady } from './utils.js';
 import { loadSettingsFromStorage, applyTheme, reflectSettingsIntoUI, wireSettingsPanel } from './settings.js';
 import { wireModals } from './modals.js';
-import { wireGenerator } from './generator.js?v=1.5.27';
+import { wireGenerator } from './generator.js?v=1.5.28';
 import { setMode, beginQuiz, renderCurrentQuestion, updateNavButtons, updateProgress, wireQuizControls, wireResultsControls, pauseTimerIfQuiz, resumeTimerIfQuiz, syncSettingsFromUI, syncExplainButtonsVisibility } from './quiz.js';
 import { has as hasFlag, hasCookie as hasCookieFlag } from './flags.js';
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,8 +8,8 @@
  * page for navigation requests when offline.
  */
 
-const ASSET_VERSION = '1.5.27';
-const CACHE_NAME = 'ezq-v1211';
+const ASSET_VERSION = '1.5.28';
+const CACHE_NAME = 'ezq-v1212';
 const PRECACHE_URLS = [
   '/index.html',
   '/styles.css?v=' + ASSET_VERSION,
@@ -38,6 +38,7 @@ const PRECACHE_URLS = [
   '/js/beta.mjs',
   '/js/import-controller.js',
   '/js/file-type-validation.js',
+  '/js/media-import-constraints.js',
   '/js/drag-drop.js',
   '/icons/icon-192.png',
   '/icons/icon-512.png',

--- a/public/ui-kit.html
+++ b/public/ui-kit.html
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>EZ Quiz UI Kit</title>
-  <script src="js/theme-preload.js?v=1.5.27"></script>
-  <link rel="stylesheet" href="styles.css?v=1.5.27">
-  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.27">
-  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.27">
+  <script src="js/theme-preload.js?v=1.5.28"></script>
+  <link rel="stylesheet" href="styles.css?v=1.5.28">
+  <link rel="stylesheet" href="/styles.tokens.css?v=1.5.28">
+  <link rel="stylesheet" href="/styles.backdrop.css?v=1.5.28">
   <style>
     body.kit-body {
       background: radial-gradient(circle at top, rgba(24, 28, 46, 0.95), rgba(6, 8, 16, 0.98));
@@ -370,8 +370,8 @@
     UI Kit mirrors production markup • <span id="kitTimestamp"></span>
   </footer>
 
-  <script src="js/boot-beta.js?v=1.5.27"></script>
-  <script src="js/ui-kit.js?v=1.5.27"></script>
+  <script src="js/boot-beta.js?v=1.5.28"></script>
+  <script src="js/ui-kit.js?v=1.5.28"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary\n- use `gh pr list --head` instead of unsupported `gh pr view --head` in the mirror publish workflow\n- precache the new unversioned `media-import-constraints.js` module in the service worker\n- bump the service worker asset/cache version so mirrored clients pick up the new precache entry\n\n## Validation\n- npm test -- --runInBand\n- npm run ui:check\n- node --check public/sw.js\n