### PR TITLE
fix: exclude internal artifacts from public mirror

### DIFF
--- a/.publicignore
+++ b/.publicignore
@@ -6,6 +6,9 @@
 .github/workflows/
 .gitignore
 .publicpreserve
+.publicworkflows
+AGENTS.md
+ENV.md
 
 # Local artifacts
 node_modules/
@@ -21,6 +24,7 @@ issues/
 tests/
 scripts/
 agents.md
+netlify/functions/__tests__/
 
 # Tests and internal tooling (uncomment if desired)
 # tests/


### PR DESCRIPTION
Exclude AGENTS.md, ENV.md, .publicworkflows, and netlify/functions/__tests__/ from the public mirror while preserving README.md via .publicpreserve.