### PR TITLE
fix(release): add missing v3.5.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2026-05-17 — v3.5.0
+- Generation
+  - Create Quiz now builds first; Start Quiz unlocks only after a valid quiz is ready.
+  - Public quiz lengths remain 5, 10, 15, and 20 while larger 30/50-question builds stay on the reliability roadmap.
+- Production
+  - Study-material import and Results explanations are part of the production flow.
+- Maintenance
+  - Version labels and package metadata updated to v3.5.0.
+
 2025-10-22 — v3.3 (hotfix) / 1.5.18-hotfix
 - Reset
   - Performs a cache-busting navigation to avoid BFCache/stale state after clearing SW + caches.


### PR DESCRIPTION
## Summary

- adds the missing v3.5.0 entry to `CHANGELOG.md`
- aligns the changelog with the existing package and UI version metadata
- restores the CI version-and-hygiene invariant

## Context

The repository was previously bumped to v3.5.0, but the matching changelog entry was omitted. This caused otherwise-unrelated pull requests, including Nodemailer PR #159, to fail `ci / verify` with `Version missing in CHANGELOG.md`.

## Validation

- content matches the existing v3.5.0 What's New copy in `public/index.html`
- no runtime code or dependencies changed