### PR TITLE
fix(generator): use compatible Blobs reads

### DIFF
--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -396,7 +396,7 @@ describe('async generation endpoints and job store', () => {
     });
   });
 
-  test('Netlify Blobs adapter uses strong reads and ETag-conditional updates', async () => {
+  test('Netlify Blobs adapter uses compatible reads and ETag-conditional updates', async () => {
     const blobStore = {
       get: jest.fn(),
       getWithMetadata: jest.fn(async () => ({
@@ -415,6 +415,7 @@ describe('async generation endpoints and job store', () => {
     try {
       const { NetlifyBlobsJobAdapter } = require('../lib/asyncJobStore.js');
       const adapter = new NetlifyBlobsJobAdapter();
+      await adapter.get('qj_abcdefghijklmnopqrstuvwxyz');
       const versioned = await adapter.getVersioned('qj_abcdefghijklmnopqrstuvwxyz');
       const modified = await adapter.setIfVersion(
         'qj_abcdefghijklmnopqrstuvwxyz',
@@ -423,10 +424,8 @@ describe('async generation endpoints and job store', () => {
       );
 
       expect(versioned).toMatchObject({ version: 'etag-1', job: { status: 'queued' } });
-      expect(blobStore.getWithMetadata).toHaveBeenCalledWith('qj_abcdefghijklmnopqrstuvwxyz', {
-        type: 'json',
-        consistency: 'strong',
-      });
+      expect(blobStore.get).toHaveBeenCalledWith('qj_abcdefghijklmnopqrstuvwxyz', { type: 'json' });
+      expect(blobStore.getWithMetadata).toHaveBeenCalledWith('qj_abcdefghijklmnopqrstuvwxyz', { type: 'json' });
       expect(blobStore.setJSON).toHaveBeenCalledWith(
         'qj_abcdefghijklmnopqrstuvwxyz',
         expect.objectContaining({ status: 'running' }),

--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -271,13 +271,13 @@ class NetlifyBlobsJobAdapter {
   async get(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
-    return this.store.get(safe, { type: 'json', consistency: 'strong' });
+    return this.store.get(safe, { type: 'json' });
   }
 
   async getVersioned(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
-    const result = await this.store.getWithMetadata(safe, { type: 'json', consistency: 'strong' });
+    const result = await this.store.getWithMetadata(safe, { type: 'json' });
     if (!result) return null;
     return { job: result.data, version: result.etag };
   }


### PR DESCRIPTION
Fixes production `BlobsConsistencyError` failures by avoiding strong-consistency reads when Netlify has not supplied `uncachedEdgeURL`. ETag-conditional writes remain intact.

Validation: async tests 33/33; full suite 30 suites, 309 tests; `git diff --check` passed.