### PR TITLE
fix(generator): recover stalled async workers

### DIFF
--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -397,10 +397,17 @@ describe('async generation endpoints and job store', () => {
   });
 
   test('Netlify Blobs adapter uses compatible reads and ETag-conditional updates', async () => {
+    const queuedJob = {
+      jobId: 'qj_abcdefghijklmnopqrstuvwxyz',
+      status: 'queued',
+      updatedAt: '2026-07-17T00:00:00.000Z',
+    };
     const blobStore = {
-      get: jest.fn(),
+      get: jest.fn()
+        .mockResolvedValueOnce(queuedJob)
+        .mockResolvedValue(null),
       getWithMetadata: jest.fn(async () => ({
-        data: { jobId: 'qj_abcdefghijklmnopqrstuvwxyz', status: 'queued' },
+        data: queuedJob,
         etag: 'etag-1',
         metadata: {},
       })),
@@ -417,13 +424,22 @@ describe('async generation endpoints and job store', () => {
       const adapter = new NetlifyBlobsJobAdapter();
       await adapter.get('qj_abcdefghijklmnopqrstuvwxyz');
       const versioned = await adapter.getVersioned('qj_abcdefghijklmnopqrstuvwxyz');
+      const repeatedRead = await adapter.get('qj_abcdefghijklmnopqrstuvwxyz');
+      const runningJob = {
+        ...queuedJob,
+        status: 'running',
+        updatedAt: '2026-07-17T00:00:01.000Z',
+      };
       const modified = await adapter.setIfVersion(
         'qj_abcdefghijklmnopqrstuvwxyz',
-        { jobId: 'qj_abcdefghijklmnopqrstuvwxyz', status: 'running', expiresAt: 'later' },
+        { ...runningJob, expiresAt: 'later' },
         versioned.version
       );
+      const readAfterWrite = await adapter.get('qj_abcdefghijklmnopqrstuvwxyz');
+      const versionedAfterWrite = await adapter.getVersioned('qj_abcdefghijklmnopqrstuvwxyz');
 
       expect(versioned).toMatchObject({ version: 'etag-1', job: { status: 'queued' } });
+      expect(repeatedRead).toMatchObject({ status: 'queued' });
       expect(blobStore.get).toHaveBeenCalledWith('qj_abcdefghijklmnopqrstuvwxyz', { type: 'json' });
       expect(blobStore.getWithMetadata).toHaveBeenCalledWith('qj_abcdefghijklmnopqrstuvwxyz', { type: 'json' });
       expect(blobStore.setJSON).toHaveBeenCalledWith(
@@ -432,9 +448,57 @@ describe('async generation endpoints and job store', () => {
         expect.objectContaining({ onlyIfMatch: 'etag-1' })
       );
       expect(modified).toBe(true);
+      expect(readAfterWrite).toMatchObject({ status: 'running' });
+      expect(versionedAfterWrite).toMatchObject({ version: 'etag-2', job: { status: 'running' } });
     } finally {
       jest.dontMock('@netlify/blobs');
     }
+  });
+
+  test('job reads retry while a newly-created Blob is not yet visible', async () => {
+    const queuedJob = {
+      jobId: 'qj_eventualvisibility1234567890',
+      status: 'queued',
+      requestedCount: 1,
+      expiresAt: new Date(Date.now() + 60000).toISOString(),
+    };
+    const adapter = {
+      get: jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(queuedJob),
+    };
+    const { GenerationJobStore } = require('../lib/asyncJobStore.js');
+    const store = new GenerationJobStore({ env: process.env, adapter });
+
+    const loaded = await store.getJobWithRetry(queuedJob.jobId, { attempts: 3, delayMs: 0 });
+
+    expect(loaded).toEqual(queuedJob);
+    expect(adapter.get).toHaveBeenCalledTimes(3);
+  });
+
+  test('conditional updates retry while Blob metadata is not yet visible', async () => {
+    const queuedJob = {
+      jobId: 'qj_eventualmetadata123456789012',
+      status: 'queued',
+      requestedCount: 1,
+      expiresAt: new Date(Date.now() + 60000).toISOString(),
+    };
+    const adapter = {
+      getVersioned: jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ job: queuedJob, version: 'etag-1' }),
+      setIfVersion: jest.fn().mockResolvedValue(true),
+    };
+    const { GenerationJobStore } = require('../lib/asyncJobStore.js');
+    const store = new GenerationJobStore({ env: process.env, adapter });
+
+    const updated = await store.updateJob(queuedJob.jobId, (job) => ({ ...job, status: 'running' }));
+
+    expect(updated).toMatchObject({ status: 'running' });
+    expect(adapter.getVersioned).toHaveBeenCalledTimes(3);
+    expect(adapter.setIfVersion).toHaveBeenCalledTimes(1);
   });
 
   test('expired jobs are scrubbed and reported safely', async () => {

--- a/netlify/functions/generate-quiz-worker-background.js
+++ b/netlify/functions/generate-quiz-worker-background.js
@@ -24,7 +24,10 @@ exports.handler = async (event) => {
   if (!jobId) return reply(400, { error: 'Invalid jobId' }, cors.origin);
 
   const store = createGenerationJobStore({ event });
-  const before = await store.getJob(jobId);
+  // Blobs reads are eventually consistent in some function environments. The
+  // browser receives the background-function 202 before this handler runs, so
+  // retry a newly-created job here instead of silently abandoning it as missing.
+  const before = await store.getJobWithRetry(jobId, { attempts: 6, delayMs: 250 });
   if (!before) return reply(404, { error: 'Job not found' }, cors.origin);
   if (!configuredBearerMatches(event) && !workerTokenMatches(before, payload && payload.workerToken)) {
     return unauthorized(cors.origin);

--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -266,31 +266,49 @@ class NetlifyBlobsJobAdapter {
       blobs.connectLambda(options.event);
     }
     this.store = blobs.getStore(STORE_NAME);
+    this.recentReads = new Map();
+    this.recentWrites = new Map();
+  }
+
+  newerRecord(remote, cached) {
+    if (!cached) return remote;
+    if (!remote) return cached;
+    const remoteUpdated = Date.parse(remote.job && remote.job.updatedAt || '');
+    const cachedUpdated = Date.parse(cached.job && cached.job.updatedAt || '');
+    return Number.isFinite(cachedUpdated) && (!Number.isFinite(remoteUpdated) || cachedUpdated >= remoteUpdated)
+      ? cached
+      : remote;
   }
 
   async get(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
-    return this.store.get(safe, { type: 'json' });
+    const job = await this.store.get(safe, { type: 'json' });
+    if (job) this.recentReads.set(safe, { job });
+    const visible = job ? { job } : this.recentReads.get(safe);
+    const record = this.newerRecord(visible, this.recentWrites.get(safe));
+    return record && record.job || null;
   }
 
   async getVersioned(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
     const result = await this.store.getWithMetadata(safe, { type: 'json' });
-    if (!result) return null;
-    return { job: result.data, version: result.etag };
+    const remote = result ? { job: result.data, version: result.etag } : null;
+    return this.newerRecord(remote, this.recentWrites.get(safe));
   }
 
   async set(jobId, job) {
     const safe = sanitizeJobId(jobId);
     if (!safe) throw new Error('Invalid jobId');
-    await this.store.setJSON(safe, job, {
+    const result = await this.store.setJSON(safe, job, {
       metadata: {
         expiresAt: job && job.expiresAt || '',
         status: job && job.status || '',
       },
     });
+    this.recentReads.set(safe, { job });
+    if (result && result.etag) this.recentWrites.set(safe, { job, version: result.etag });
   }
 
   async setIfVersion(jobId, job, version) {
@@ -303,12 +321,18 @@ class NetlifyBlobsJobAdapter {
         status: job && job.status || '',
       },
     });
-    return !!(result && result.modified);
+    const modified = !!(result && result.modified);
+    if (modified) this.recentReads.set(safe, { job });
+    if (modified && result.etag) this.recentWrites.set(safe, { job, version: result.etag });
+    if (!modified) this.recentWrites.delete(safe);
+    return modified;
   }
 
   async delete(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return;
+    this.recentReads.delete(safe);
+    this.recentWrites.delete(safe);
     await this.store.delete(safe);
   }
 }
@@ -372,6 +396,19 @@ class GenerationJobStore {
     return job;
   }
 
+  async getJobWithRetry(jobId, options = {}) {
+    const attempts = Math.max(1, Number(options.attempts || 1));
+    const delayMs = Math.max(0, Number(options.delayMs || 0));
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const job = await this.getJob(jobId);
+      if (job) return job;
+      if (attempt < attempts - 1 && delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs * (attempt + 1)));
+      }
+    }
+    return null;
+  }
+
   async saveJob(job) {
     const safe = sanitizeJobId(job && job.jobId);
     if (!safe) throw new Error('Invalid jobId');
@@ -387,12 +424,18 @@ class GenerationJobStore {
       const supportsConditionalWrite = typeof this.adapter.getVersioned === 'function'
         && typeof this.adapter.setIfVersion === 'function';
       const attempts = supportsConditionalWrite ? 8 : 1;
+      let sawCurrent = false;
       for (let attempt = 0; attempt < attempts; attempt += 1) {
         const versioned = supportsConditionalWrite ? await this.adapter.getVersioned(safe) : null;
+        if (supportsConditionalWrite && !versioned) {
+          await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+          continue;
+        }
         const current = supportsConditionalWrite
           ? versioned && versioned.job
           : await this.getJob(safe);
         if (!current) return null;
+        sawCurrent = true;
         if (jobExpired(current)) {
           await this.adapter.delete(safe);
           return expiredJob(safe, current);
@@ -407,7 +450,9 @@ class GenerationJobStore {
           return next;
         }
         if (await this.adapter.setIfVersion(safe, next, versioned.version)) return next;
+        await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
       }
+      if (!sawCurrent) return null;
       const err = new Error('Generation job changed too many times; retry the request.');
       err.code = 'JOB_UPDATE_CONFLICT';
       throw err;

--- a/public/js/generator.js
+++ b/public/js/generator.js
@@ -927,6 +927,7 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
 
   async function pollAsyncGenerationJob(session, payload){
     let pollingFailures = 0;
+    let queuedPolls = 0;
     while(isActiveGeneration(session.id)){
       let status;
       try{
@@ -969,6 +970,7 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
       const state = String(status && status.status || '').toLowerCase();
       const completed = Number(status && status.completedCount || 0);
       const requested = Number(status && status.requestedCount || payload.count || 0);
+      queuedPolls = state === 'queued' && completed === 0 ? queuedPolls + 1 : 0;
       setGenerationStatusState('generating', {
         requestId: session.id,
         metadata: formatGenerationMetadata(payload),
@@ -981,6 +983,15 @@ export function wireGenerator({ beginQuiz, syncSettingsFromUI }){
 
       if(state === 'complete' || state === 'partial' || state === 'failed' || state === 'stopped' || state === 'canceled' || state === 'expired'){
         return status;
+      }
+      if(queuedPolls > 0 && queuedPolls % 3 === 0 && queuedPolls < 9){
+        try{ await triggerAsyncGeneration(session.jobId, session.workerToken); }catch{}
+      }
+      if(queuedPolls >= 9){
+        try{ await requestAsyncGenerationStop(session); }catch{}
+        const failed = new Error('Generation worker did not start. Please try again.');
+        failed.name = 'AsyncGenerationWorkerTimeout';
+        throw failed;
       }
       if(session.stopRefreshPending) {
         session.stopRefreshPending = false;

--- a/tests/generator-overlapping-imports.test.js
+++ b/tests/generator-overlapping-imports.test.js
@@ -1033,6 +1033,38 @@ describe('generator media import overlap regression', () => {
     }));
   });
 
+  test('queued async jobs are retriggered and stopped instead of polling forever', async () => {
+    setMediaSource({
+      text: 'Q'.repeat(25000),
+      name: 'queued-notes.md',
+      charCount: 25000,
+      report: makeSourceReport({ charCount: 25000, sectionCount: 55, quizWorthyCount: 50 }),
+    });
+    getAsyncGenerationStatus.mockResolvedValue({
+      status: 'queued',
+      completedCount: 0,
+      requestedCount: 50,
+      progressMessage: 'Generation job queued.',
+    });
+
+    document.getElementById('topicInput').value = 'queued worker';
+    document.getElementById('countInput').value = '50';
+    document.getElementById('generateBtn').dispatchEvent(new Event('click', { bubbles: true }));
+    await flushUntil(() => stopAsyncGeneration.mock.calls.length > 0);
+    await flush();
+
+    expect(getAsyncGenerationStatus).toHaveBeenCalledTimes(9);
+    expect(triggerAsyncGeneration).toHaveBeenCalledTimes(3);
+    expect(stopAsyncGeneration).toHaveBeenCalledWith(
+      'qj_abcdefghijklmnopqrstuvwxyz123456',
+      { workerToken: 'worker_capability_abcdefghijklmnopqrstuvwxyz' }
+    );
+    expect(generateWithAI).not.toHaveBeenCalled();
+    expect(document.getElementById('generationStatusCard').dataset.generationState).toBe('error');
+    expect(document.getElementById('generationStatusMessage').textContent)
+      .toContain('Generation worker did not start');
+  });
+
   test('async partial result enables Start with usable questions', async () => {
     const lines = generatedTfLines(12);
     setMediaSource({


### PR DESCRIPTION
## What changed

- retry newly-created job reads before a background worker gives up
- preserve recent Blob reads and writes inside a worker invocation so eventual consistency cannot erase its lease or progress
- back off and retry temporarily invisible/conflicting ETag updates
- retrigger jobs that remain queued and stop with a clear error after 90 seconds instead of polling forever

## Root cause

Netlify accepted the background-function request with `202`, but the worker could immediately miss the newly written job through an eventually consistent Blob read and exit. Status polling then correctly returned `200` for the permanently queued job.

## Validation

- focused async/store and generator regression tests: 83 passed
- full suite: 30 suites, 312 tests passed
- `git diff --check` passed