### PR TITLE
fix(generator): preserve versioned job retries

### DIFF
--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -532,6 +532,27 @@ describe('async generation endpoints and job store', () => {
     expect(adapter.get).toHaveBeenCalledTimes(1);
   });
 
+  test('versioned retry reads preserve expiry cleanup and response state', async () => {
+    const expired = {
+      jobId: 'qj_expiredversionedretry123456',
+      status: 'queued',
+      options: { sourceText: 'private material' },
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    };
+    const adapter = {
+      getVersioned: jest.fn().mockResolvedValue({ job: expired, version: 'etag-expired' }),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    const { GenerationJobStore } = require('../lib/asyncJobStore.js');
+    const store = new GenerationJobStore({ env: process.env, adapter });
+
+    const loaded = await store.getJobWithRetry(expired.jobId, { attempts: 3, delayMs: 0 });
+
+    expect(loaded).toMatchObject({ status: 'expired', jobId: expired.jobId });
+    expect(JSON.stringify(loaded)).not.toContain('private material');
+    expect(adapter.delete).toHaveBeenCalledWith(expired.jobId);
+  });
+
   test('conditional updates retry while Blob metadata is not yet visible', async () => {
     const queuedJob = {
       jobId: 'qj_eventualmetadata123456789012',

--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -489,7 +489,11 @@ describe('async generation endpoints and job store', () => {
       get: jest.fn(),
       getWithMetadata: jest.fn()
         .mockResolvedValueOnce({ data: queuedJob, etag: 'etag-1', metadata: {} })
-        .mockResolvedValueOnce(null),
+        .mockResolvedValueOnce({
+          data: { ...queuedJob, updatedAt: '2026-07-16T23:59:59.000Z' },
+          etag: 'etag-stale',
+          metadata: {},
+        }),
       setJSON: jest.fn(async () => ({ modified: true, etag: 'etag-2' })),
       delete: jest.fn(),
     };

--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -477,6 +477,61 @@ describe('async generation endpoints and job store', () => {
     expect(adapter.get).toHaveBeenCalledTimes(3);
   });
 
+  test('a successful versioned retry remains usable when the next Blob read is stale', async () => {
+    const queuedJob = {
+      jobId: 'qj_versionedvisibility123456789',
+      status: 'queued',
+      requestedCount: 1,
+      updatedAt: '2026-07-17T00:00:00.000Z',
+      expiresAt: new Date(Date.now() + 60000).toISOString(),
+    };
+    const blobStore = {
+      get: jest.fn(),
+      getWithMetadata: jest.fn()
+        .mockResolvedValueOnce({ data: queuedJob, etag: 'etag-1', metadata: {} })
+        .mockResolvedValueOnce(null),
+      setJSON: jest.fn(async () => ({ modified: true, etag: 'etag-2' })),
+      delete: jest.fn(),
+    };
+    jest.doMock('@netlify/blobs', () => ({
+      connectLambda: jest.fn(),
+      getStore: jest.fn(() => blobStore),
+    }));
+
+    try {
+      const { GenerationJobStore, NetlifyBlobsJobAdapter } = require('../lib/asyncJobStore.js');
+      const adapter = new NetlifyBlobsJobAdapter();
+      const store = new GenerationJobStore({ env: process.env, adapter });
+      const loaded = await store.getJobWithRetry(queuedJob.jobId, { attempts: 3, delayMs: 0 });
+      const updated = await store.updateJob(queuedJob.jobId, (job) => ({ ...job, status: 'running' }));
+
+      expect(loaded).toEqual(queuedJob);
+      expect(updated).toMatchObject({ status: 'running' });
+      expect(blobStore.getWithMetadata).toHaveBeenCalledTimes(2);
+      expect(blobStore.setJSON).toHaveBeenCalledWith(
+        queuedJob.jobId,
+        expect.objectContaining({ status: 'running' }),
+        expect.objectContaining({ onlyIfMatch: 'etag-1' })
+      );
+    } finally {
+      jest.dontMock('@netlify/blobs');
+    }
+  });
+
+  test('invalid retry options safely fall back to one immediate attempt', async () => {
+    const adapter = { get: jest.fn().mockResolvedValue(null) };
+    const { GenerationJobStore } = require('../lib/asyncJobStore.js');
+    const store = new GenerationJobStore({ env: process.env, adapter });
+
+    const loaded = await store.getJobWithRetry('qj_invalidretryoptions123456789', {
+      attempts: 'not-a-number',
+      delayMs: 'also-not-a-number',
+    });
+
+    expect(loaded).toBeNull();
+    expect(adapter.get).toHaveBeenCalledTimes(1);
+  });
+
   test('conditional updates retry while Blob metadata is not yet visible', async () => {
     const queuedJob = {
       jobId: 'qj_eventualmetadata123456789012',

--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -296,11 +296,11 @@ class NetlifyBlobsJobAdapter {
     if (!safe) return null;
     const result = await this.store.getWithMetadata(safe, { type: 'json' });
     const remote = result ? { job: result.data, version: result.etag } : null;
-    if (remote) {
-      this.recentReads.set(safe, { job: remote.job });
-      this.recentVersions.set(safe, remote);
-    }
     const visible = this.newerRecord(remote, this.recentVersions.get(safe));
+    if (visible) {
+      this.recentReads.set(safe, { job: visible.job });
+      this.recentVersions.set(safe, visible);
+    }
     return this.newerRecord(visible, this.recentWrites.get(safe));
   }
 

--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -425,7 +425,13 @@ class GenerationJobStore {
       const job = supportsVersionedRead
         ? versioned && versioned.job
         : await this.adapter.get(safe);
-      if (job) return job;
+      if (job) {
+        if (jobExpired(job)) {
+          await this.adapter.delete(safe);
+          return expiredJob(safe, job);
+        }
+        return job;
+      }
       if (attempt < attempts - 1 && delayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, delayMs * (attempt + 1)));
       }

--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -267,6 +267,7 @@ class NetlifyBlobsJobAdapter {
     }
     this.store = blobs.getStore(STORE_NAME);
     this.recentReads = new Map();
+    this.recentVersions = new Map();
     this.recentWrites = new Map();
   }
 
@@ -295,7 +296,12 @@ class NetlifyBlobsJobAdapter {
     if (!safe) return null;
     const result = await this.store.getWithMetadata(safe, { type: 'json' });
     const remote = result ? { job: result.data, version: result.etag } : null;
-    return this.newerRecord(remote, this.recentWrites.get(safe));
+    if (remote) {
+      this.recentReads.set(safe, { job: remote.job });
+      this.recentVersions.set(safe, remote);
+    }
+    const visible = this.newerRecord(remote, this.recentVersions.get(safe));
+    return this.newerRecord(visible, this.recentWrites.get(safe));
   }
 
   async set(jobId, job) {
@@ -308,7 +314,10 @@ class NetlifyBlobsJobAdapter {
       },
     });
     this.recentReads.set(safe, { job });
-    if (result && result.etag) this.recentWrites.set(safe, { job, version: result.etag });
+    if (result && result.etag) {
+      this.recentVersions.set(safe, { job, version: result.etag });
+      this.recentWrites.set(safe, { job, version: result.etag });
+    }
   }
 
   async setIfVersion(jobId, job, version) {
@@ -323,8 +332,14 @@ class NetlifyBlobsJobAdapter {
     });
     const modified = !!(result && result.modified);
     if (modified) this.recentReads.set(safe, { job });
-    if (modified && result.etag) this.recentWrites.set(safe, { job, version: result.etag });
-    if (!modified) this.recentWrites.delete(safe);
+    if (modified && result.etag) {
+      this.recentVersions.set(safe, { job, version: result.etag });
+      this.recentWrites.set(safe, { job, version: result.etag });
+    }
+    if (!modified) {
+      this.recentVersions.delete(safe);
+      this.recentWrites.delete(safe);
+    }
     return modified;
   }
 
@@ -332,6 +347,7 @@ class NetlifyBlobsJobAdapter {
     const safe = sanitizeJobId(jobId);
     if (!safe) return;
     this.recentReads.delete(safe);
+    this.recentVersions.delete(safe);
     this.recentWrites.delete(safe);
     await this.store.delete(safe);
   }
@@ -397,10 +413,18 @@ class GenerationJobStore {
   }
 
   async getJobWithRetry(jobId, options = {}) {
-    const attempts = Math.max(1, Number(options.attempts || 1));
-    const delayMs = Math.max(0, Number(options.delayMs || 0));
+    const safe = sanitizeJobId(jobId);
+    if (!safe) return null;
+    const parsedAttempts = Number(options.attempts);
+    const parsedDelayMs = Number(options.delayMs);
+    const attempts = Number.isFinite(parsedAttempts) ? Math.max(1, Math.floor(parsedAttempts)) : 1;
+    const delayMs = Number.isFinite(parsedDelayMs) ? Math.max(0, parsedDelayMs) : 0;
+    const supportsVersionedRead = typeof this.adapter.getVersioned === 'function';
     for (let attempt = 0; attempt < attempts; attempt += 1) {
-      const job = await this.getJob(jobId);
+      const versioned = supportsVersionedRead ? await this.adapter.getVersioned(safe) : null;
+      const job = supportsVersionedRead
+        ? versioned && versioned.job
+        : await this.adapter.get(safe);
       if (job) return job;
       if (attempt < attempts - 1 && delayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, delayMs * (attempt + 1)));


### PR DESCRIPTION
Follow-up to #177 addressing its late review findings.

- use versioned Blob reads during initial worker retry and retain the visible ETag across a stale follow-up read
- clear cached versions after conditional conflicts so external stop/progress changes can win
- safely normalize invalid retry options
- preserve expiry cleanup and scrubbed expired responses on the versioned retry path

Validation: focused async suite 38/38; full suite 30 suites and 315 tests; `git diff --check` passed.