### PR TITLE
fix(generator): restore async quiz quality guidance

### DIFF
--- a/netlify/functions/__tests__/async-generation.test.js
+++ b/netlify/functions/__tests__/async-generation.test.js
@@ -1165,6 +1165,29 @@ describe('async generation worker', () => {
     });
   });
 
+  test('source-framed stems are rejected and replaced during source-backed generation', async () => {
+    const framed = 'YN|According to the CCNA Notes, does a router separate broadcast domains?|Y';
+    const standalone = 'YN|Does a router separate broadcast domains?|Y';
+    handleGenerateQuiz
+      .mockResolvedValueOnce(okLines([framed]))
+      .mockResolvedValueOnce(okLines([standalone]));
+    const job = await createWorkerJob([
+      plannedSectionBatch(1, 1, ['YN']),
+    ], { requestedCount: 1, options: { difficulty: 'hard' } });
+
+    const done = await processGenerationJob(job.jobId, { store });
+
+    expect(done.status).toBe('complete');
+    expect(done.questions).toEqual([standalone]);
+    expect(done.questions).not.toContain(framed);
+    expect(done.failedBatches[0]).toMatchObject({
+      rawLineCount: 1,
+      acceptedCount: 0,
+      rejectedCount: 1,
+      rejectedReasons: { source_framing: 1 },
+    });
+  });
+
   test('one failed batch is recorded and fill pass runs after later planned batches', async () => {
     handleGenerateQuiz
       .mockResolvedValueOnce(timeoutResponse())

--- a/netlify/functions/__tests__/providers.test.js
+++ b/netlify/functions/__tests__/providers.test.js
@@ -180,9 +180,17 @@ describe('providers helpers', () => {
     expect(out).toContain('Scenario framing: ON');
     expect(out).toContain('Curveball: OFF');
     expect(out).toContain('Create deterministic study questions about config behavior.');
-    expect(out).toContain('Use only the source excerpts below.');
+    expect(out).not.toContain('about CCNA Notes');
+    expect(out).not.toContain('Use only the source excerpts below.');
+    expect(out).toContain('Use only the private instructor knowledge below for factual content.');
+    expect(out).toContain('PRIVATE INSTRUCTOR KNOWLEDGE START');
+    expect(out).toContain('PRIVATE INSTRUCTOR KNOWLEDGE END');
+    expectSourceHiddenFraming(out);
+    expectSharedDifficultyGuidance(out, 'Hard');
+    expect(out).toContain('Hard: test applied judgment');
     expect(out).toContain('Return only valid EZ Quiz YN lines.');
     expect(out).toContain('Avoid repeating these already-used question stems: Old config stem?.');
+    expect(out).toContain('do not merely paraphrase an avoided stem');
     expect(out).toContain('YN|A yes/no question?|Y');
     expect(out).not.toContain('Allowed question types');
     expect(out).not.toContain('use scenarios where appropriate');

--- a/netlify/functions/lib/asyncGenerationWorker.js
+++ b/netlify/functions/lib/asyncGenerationWorker.js
@@ -136,7 +136,13 @@ function summarizeRejections(reasons) {
   }, {});
 }
 
-function collectUniqueQuizLines(rawLines, state, limit) {
+function hasSourceFraming(stem) {
+  const text = String(stem || '');
+  return /\b(?:according to|based (?:solely )?on)\s+(?:the\s+)?(?:provided\s+)?(?:[\w-]+\s+){0,3}(?:notes?|source material|study material|documentation|document|text|excerpts?|handout|reading|lesson)\b/i.test(text)
+    || /\b(?:the\s+)?(?:[\w-]+\s+){0,2}notes?\s+(?:state|states|say|says|indicate|indicates)\b/i.test(text);
+}
+
+function collectUniqueQuizLines(rawLines, state, limit, options = {}) {
   const raw = splitLines(rawLines);
   const accepted = [];
   const acceptedRecords = [];
@@ -155,6 +161,10 @@ function collectUniqueQuizLines(rawLines, state, limit) {
     const key = normalizedStem(stem);
     if (!stem || !key) {
       rejectedReasons.push('missing_stem');
+      continue;
+    }
+    if (options.sourceBacked && hasSourceFraming(stem)) {
+      rejectedReasons.push('source_framing');
       continue;
     }
     if (localSeen.has(key)) {
@@ -587,7 +597,9 @@ async function processOneBatch(store, job, batch, state, options = {}) {
     if (target <= 0 || requestedCount <= 0) return { stopped: false };
     const providerBatch = alignPlannedBatchForProvider(batch, requestedCount);
     const body = await runGenerateBatch(job, providerBatch, state);
-    const collection = collectUniqueQuizLines(body.lines, state, target);
+    const collection = collectUniqueQuizLines(body.lines, state, target, {
+      sourceBacked: !!providerBatch.sourceText,
+    });
     const accepted = collection.accepted;
     state.acceptedCount += accepted.length;
     if (accepted.length) {

--- a/netlify/functions/lib/providers.js
+++ b/netlify/functions/lib/providers.js
@@ -272,8 +272,13 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
   const contract = normalizeLaneContract(laneContract, count, types);
   if (!contract) return '';
   const source = cleanSourceMaterial(sourceText);
+  const diffLine = difficultyGuidance(difficulty);
+  const sourceBlock = source ? privateInstructorKnowledgeBlock(source) : '';
   const avoid = Array.isArray(avoidStems) && avoidStems.length
-    ? `Avoid repeating these already-used question stems: ${avoidStems.slice(-60).join(' | ')}.`
+    ? [
+      `Avoid repeating these already-used question stems: ${avoidStems.slice(-60).join(' | ')}.`,
+      `Test a meaningfully different underlying concept, answer, command, or behavior; do not merely paraphrase an avoided stem.`,
+    ].join('\n')
     : '';
   const curveballLine = contract.curveball
     ? `Curveball: create exactly ${Math.max(1, contract.curveballCount)} fair expert curveball in this batch. It must be source-grounded, test an edge case, exception, misleading assumption, or hidden dependency, and have one clearly correct answer.`
@@ -289,8 +294,11 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
     curveballLine,
     '',
     'Task:',
-    `${laneTaskLine(contract)} about ${topic}.`,
-    source ? 'Use only the source excerpts below.' : '',
+    laneTaskLine(contract),
+    source ? '' : `Quiz topic: ${topic}.`,
+    source ? sourceFramingInstructions() : '',
+    source ? 'Use only the private instructor knowledge below for factual content.' : '',
+    diffLine,
     contract.scenario ? 'Keep scenarios short and answerable.' : 'Do not add scenario framing; use direct standalone stems.',
     `Return only valid EZ Quiz ${contract.questionType} lines.`,
     'No explanations.',
@@ -300,9 +308,7 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
     '',
     'Output format:',
     lineFormatForType(contract.questionType),
-    source ? '' : '',
-    source ? 'Source excerpts:' : '',
-    source || '',
+    sourceBlock,
   ].filter((line) => line !== '').join('\n');
 }
 


### PR DESCRIPTION
## Root cause

The compact async lane prompt accepted `difficulty` but never included `difficultyGuidance()`, and it bypassed the hidden-source framing used by the established prompt builders. This caused easy recall questions at Hard difficulty and encouraged stems such as “According to the CCNA Notes.”

## Fix

- restore full Hard/Expert reasoning guidance in lane prompts
- restore private-instructor-knowledge framing and remove source labels/topic filenames from source-backed tasks
- tell each batch to avoid the underlying concepts of prior stems, not merely exact wording
- reject source-framed generated stems deterministically and fill replacements

## Validation

- focused provider/async regressions: 64 passed
- full suite: 30 suites, 316 tests passed
- `git diff --check` passed