### PR TITLE
fix(mirror): preserve App README media

### DIFF
--- a/.publicpreserve
+++ b/.publicpreserve
@@ -2,3 +2,4 @@
 # These are excluded only from the destination sync pass, so the mirror
 # will not overwrite or delete the downstream copy.
 README.md
+public/readme-media/


### PR DESCRIPTION
Prevents the canonical Dev → App mirror from deleting production-only media referenced by the preserved App README.

- preserves `public/readme-media/` alongside `README.md`
- keeps App staging focused on the plugin/runtime promotion
- follows the existing `.publicpreserve` mechanism