### PR TITLE
fix(plugin): refresh padded results widget

### DIFF
--- a/netlify/functions/__tests__/mcp.test.js
+++ b/netlify/functions/__tests__/mcp.test.js
@@ -95,7 +95,7 @@ describe('EZ Quiz MCP server', () => {
     expect(listedTools[0]).toMatchObject({
       inputSchema: { required: ['title', 'topic', 'questions'], additionalProperties: false },
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v4.html' } },
+      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v5.html' } },
     });
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('source_text');
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('lines');
@@ -143,6 +143,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v2.html',
       'ui://ez-quiz/quiz-v3.html',
       'ui://ez-quiz/quiz-v4.html',
+      'ui://ez-quiz/quiz-v5.html',
     ]);
 
     for (const uri of [
@@ -150,6 +151,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v2.html',
       'ui://ez-quiz/quiz-v3.html',
       'ui://ez-quiz/quiz-v4.html',
+      'ui://ez-quiz/quiz-v5.html',
     ]) {
       const read = await handler(event({ jsonrpc: '2.0', id: 32, method: 'resources/read', params: { uri } }));
       expect(json(read).result.contents[0]).toMatchObject({ uri, mimeType: 'text/html;profile=mcp-app' });

--- a/netlify/functions/lib/mcpQuizWidget.js
+++ b/netlify/functions/lib/mcpQuizWidget.js
@@ -4,11 +4,12 @@ const { BRAND_WORDMARK_DATA_URI } = require('./mcpQuizBrand.js');
 
 // Widget template URIs are cache keys. Publish breaking layout revisions under
 // a fresh URI while continuing to serve old aliases for cached tool descriptors.
-const QUIZ_WIDGET_URI = 'ui://ez-quiz/quiz-v4.html';
+const QUIZ_WIDGET_URI = 'ui://ez-quiz/quiz-v5.html';
 const QUIZ_WIDGET_ALIASES = Object.freeze([
   'ui://ez-quiz/quiz-v1.html',
   'ui://ez-quiz/quiz-v2.html',
   'ui://ez-quiz/quiz-v3.html',
+  'ui://ez-quiz/quiz-v4.html',
   QUIZ_WIDGET_URI,
 ]);
 const QUIZ_WIDGET_MIME_TYPE = 'text/html;profile=mcp-app';


### PR DESCRIPTION
## Summary
- publish the padded results layout under `ui://ez-quiz/quiz-v5.html` so ChatGPT does not reuse cached v4 CSS
- continue serving widget v1–v4 aliases for existing conversations
- update MCP contract coverage for the v5 resource

## Verification
- focused MCP suite: 23/23 passed
- full suite: 31 suites, 339/339 tests passed
- `git diff --check` passed