### PR TITLE
Fix results padding in embedded WebViews

### DIFF
--- a/netlify/functions/__tests__/mcp.test.js
+++ b/netlify/functions/__tests__/mcp.test.js
@@ -95,7 +95,7 @@ describe('EZ Quiz MCP server', () => {
     expect(listedTools[0]).toMatchObject({
       inputSchema: { required: ['title', 'topic', 'questions'], additionalProperties: false },
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v5.html' } },
+      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v6.html' } },
     });
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('source_text');
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('lines');
@@ -144,6 +144,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v3.html',
       'ui://ez-quiz/quiz-v4.html',
       'ui://ez-quiz/quiz-v5.html',
+      'ui://ez-quiz/quiz-v6.html',
     ]);
 
     for (const uri of [
@@ -152,6 +153,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v3.html',
       'ui://ez-quiz/quiz-v4.html',
       'ui://ez-quiz/quiz-v5.html',
+      'ui://ez-quiz/quiz-v6.html',
     ]) {
       const read = await handler(event({ jsonrpc: '2.0', id: 32, method: 'resources/read', params: { uri } }));
       expect(json(read).result.contents[0]).toMatchObject({ uri, mimeType: 'text/html;profile=mcp-app' });
@@ -539,7 +541,11 @@ describe('EZ Quiz MCP server', () => {
     clickInput('input[value="false"]');
     document.querySelector('#next').click();
     expect(document.documentElement.dataset.size).toBeUndefined();
-    expect(html).toContain('padding: 20px clamp(22px, 5vw, 28px) 22px;');
+    expect(html).toContain('padding: 20px 22px 22px;');
+    const resultsStyle = window.getComputedStyle(document.querySelector('#root'));
+    expect(resultsStyle.paddingLeft).toBe('22px');
+    expect(resultsStyle.paddingRight).toBe('22px');
+    expect(resultsStyle.paddingBottom).toBe('22px');
     expect(document.querySelector('.result-summary').textContent).toContain('Question 2');
     expect(document.querySelectorAll('.result-actions button')).toHaveLength(2);
     expect(document.querySelector('#retakeMissed').disabled).toBe(false);

--- a/netlify/functions/lib/mcpQuizWidget.js
+++ b/netlify/functions/lib/mcpQuizWidget.js
@@ -4,12 +4,13 @@ const { BRAND_WORDMARK_DATA_URI } = require('./mcpQuizBrand.js');
 
 // Widget template URIs are cache keys. Publish breaking layout revisions under
 // a fresh URI while continuing to serve old aliases for cached tool descriptors.
-const QUIZ_WIDGET_URI = 'ui://ez-quiz/quiz-v5.html';
+const QUIZ_WIDGET_URI = 'ui://ez-quiz/quiz-v6.html';
 const QUIZ_WIDGET_ALIASES = Object.freeze([
   'ui://ez-quiz/quiz-v1.html',
   'ui://ez-quiz/quiz-v2.html',
   'ui://ez-quiz/quiz-v3.html',
   'ui://ez-quiz/quiz-v4.html',
+  'ui://ez-quiz/quiz-v5.html',
   QUIZ_WIDGET_URI,
 ]);
 const QUIZ_WIDGET_MIME_TYPE = 'text/html;profile=mcp-app';
@@ -165,7 +166,8 @@ function quizWidgetHtml() {
     .ezq-main:focus { outline: none; }
     .app[data-view="results"] .ezq-main {
       display: block;
-      padding: 20px clamp(22px, 5vw, 28px) 22px;
+      /* Embedded WebViews must resolve this gutter without modern CSS math. */
+      padding: 20px 22px 22px;
       overflow: visible;
     }
     .app[data-view="status"] .ezq-main {


### PR DESCRIPTION
## Summary
- replace the results-only `clamp()` gutter with a literal 22px inset so embedded Android WebViews cannot discard the padding declaration
- publish the corrected widget as `quiz-v6.html` while preserving v1-v5 aliases
- assert the rendered results root computes to 22px left, right, and bottom padding

## Verification
- focused MCP suite: 23/23 passed
- full suite: 31 suites, 339/339 tests passed
- `git diff --check` passed