### PR TITLE
Inset the actual results content in the widget

### DIFF
--- a/netlify/functions/__tests__/mcp.test.js
+++ b/netlify/functions/__tests__/mcp.test.js
@@ -95,7 +95,7 @@ describe('EZ Quiz MCP server', () => {
     expect(listedTools[0]).toMatchObject({
       inputSchema: { required: ['title', 'topic', 'questions'], additionalProperties: false },
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v6.html' } },
+      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v7.html' } },
     });
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('source_text');
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('lines');
@@ -145,6 +145,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v4.html',
       'ui://ez-quiz/quiz-v5.html',
       'ui://ez-quiz/quiz-v6.html',
+      'ui://ez-quiz/quiz-v7.html',
     ]);
 
     for (const uri of [
@@ -154,6 +155,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v4.html',
       'ui://ez-quiz/quiz-v5.html',
       'ui://ez-quiz/quiz-v6.html',
+      'ui://ez-quiz/quiz-v7.html',
     ]) {
       const read = await handler(event({ jsonrpc: '2.0', id: 32, method: 'resources/read', params: { uri } }));
       expect(json(read).result.contents[0]).toMatchObject({ uri, mimeType: 'text/html;profile=mcp-app' });
@@ -541,11 +543,17 @@ describe('EZ Quiz MCP server', () => {
     clickInput('input[value="false"]');
     document.querySelector('#next').click();
     expect(document.documentElement.dataset.size).toBeUndefined();
-    expect(html).toContain('padding: 20px 22px 22px;');
-    const resultsStyle = window.getComputedStyle(document.querySelector('#root'));
+    const resultsView = document.querySelector('.results-view');
+    expect(resultsView).not.toBeNull();
+    expect(resultsView.dataset.widgetVersion).toBe('7');
+    expect(resultsView.style.padding).toBe('20px 22px 22px');
+    expect(resultsView.contains(document.querySelector('.score-orb'))).toBe(true);
+    expect(resultsView.contains(document.querySelector('.result-actions'))).toBe(true);
+    const resultsStyle = window.getComputedStyle(resultsView);
     expect(resultsStyle.paddingLeft).toBe('22px');
     expect(resultsStyle.paddingRight).toBe('22px');
     expect(resultsStyle.paddingBottom).toBe('22px');
+    expect(document.querySelector('.widget-build').textContent).toBe('v7');
     expect(document.querySelector('.result-summary').textContent).toContain('Question 2');
     expect(document.querySelectorAll('.result-actions button')).toHaveLength(2);
     expect(document.querySelector('#retakeMissed').disabled).toBe(false);

--- a/netlify/functions/lib/mcpQuizWidget.js
+++ b/netlify/functions/lib/mcpQuizWidget.js
@@ -4,13 +4,15 @@ const { BRAND_WORDMARK_DATA_URI } = require('./mcpQuizBrand.js');
 
 // Widget template URIs are cache keys. Publish breaking layout revisions under
 // a fresh URI while continuing to serve old aliases for cached tool descriptors.
-const QUIZ_WIDGET_URI = 'ui://ez-quiz/quiz-v6.html';
+const QUIZ_WIDGET_VERSION = 7;
+const QUIZ_WIDGET_URI = `ui://ez-quiz/quiz-v${QUIZ_WIDGET_VERSION}.html`;
 const QUIZ_WIDGET_ALIASES = Object.freeze([
   'ui://ez-quiz/quiz-v1.html',
   'ui://ez-quiz/quiz-v2.html',
   'ui://ez-quiz/quiz-v3.html',
   'ui://ez-quiz/quiz-v4.html',
   'ui://ez-quiz/quiz-v5.html',
+  'ui://ez-quiz/quiz-v6.html',
   QUIZ_WIDGET_URI,
 ]);
 const QUIZ_WIDGET_MIME_TYPE = 'text/html;profile=mcp-app';
@@ -166,8 +168,7 @@ function quizWidgetHtml() {
     .ezq-main:focus { outline: none; }
     .app[data-view="results"] .ezq-main {
       display: block;
-      /* Embedded WebViews must resolve this gutter without modern CSS math. */
-      padding: 20px 22px 22px;
+      padding: 0;
       overflow: visible;
     }
     .app[data-view="status"] .ezq-main {
@@ -323,6 +324,7 @@ function quizWidgetHtml() {
       font-weight: 850;
     }
     .status-card p { margin: 8px 0 0; color: var(--muted); }
+    .results-view { padding: 20px 22px 22px; }
     .results-head { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 16px; }
     .score-orb {
       display: grid;
@@ -366,6 +368,7 @@ function quizWidgetHtml() {
     .result-summary strong { color: var(--text); }
     .result-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 14px; }
     .result-note { margin: 13px 0 0; color: var(--muted); font-size: 12px; text-align: center; }
+    .widget-build { margin-left: 5px; font-size: 9px; letter-spacing: .04em; opacity: .55; }
     .ezq-main[data-density="tight"] .question-content { padding-top: 10px; padding-bottom: 6px; }
     .ezq-main[data-density="tight"] .topline { margin-bottom: 4px; }
     .ezq-main[data-density="tight"] .eyebrow,
@@ -871,7 +874,7 @@ function quizWidgetHtml() {
           ? '<strong>Review next:</strong> ' + missed.map((questionIndex) => 'Question ' + (questionIndex + 1)).join(', ')
           : '<strong>All correct.</strong> You are ready for a harder round.';
         renderHtml(
-          '<div class="results-head"><div class="score-orb" aria-label="' + score + ' out of ' + quiz.questions.length + '">' + score + '/' + quiz.questions.length + '</div>' +
+          '<section class="results-view" data-widget-version="${QUIZ_WIDGET_VERSION}" style="padding:20px 22px 22px"><div class="results-head"><div class="score-orb" aria-label="' + score + ' out of ' + quiz.questions.length + '">' + score + '/' + quiz.questions.length + '</div>' +
           '<div class="results-copy"><h1>Quiz complete</h1><p>' + esc(message) + ' · ' + formatDuration(finishedAt - startedAt) + '</p></div></div>' +
           '<div class="result-progress"><div class="progress" role="progressbar" aria-label="Final score" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' + percent + '">' +
           '<span style="width:' + percent + '%"></span></div></div>' +
@@ -881,7 +884,7 @@ function quizWidgetHtml() {
           '<div class="result-summary">' + missedSummary + '</div>' +
           '<div class="result-actions"><button id="retakeMissed" class="primary" type="button" ' + (!missed.length ? 'disabled' : '') + '>Retake missed</button>' +
           '<button id="retakeAll" class="secondary" type="button">Retake all</button></div>' +
-          '<p class="result-note">' + esc(quiz.title) + '</p>',
+          '<p class="result-note">' + esc(quiz.title) + '<span class="widget-build">v${QUIZ_WIDGET_VERSION}</span></p></section>',
           'results'
         );
         document.getElementById('retakeMissed').addEventListener('click', () => beginRetake(missed));


### PR DESCRIPTION
## Summary
- wrap the complete results subtree in a dedicated `.results-view`
- apply the 20px/22px gutter directly to that wrapper with an inline fallback
- reset the parent results root to zero so supported hosts do not double-pad
- publish `quiz-v7.html` and show a subtle `v7` marker beside the quiz title for real-device confirmation

## Regression coverage
- verifies the score, summary, and retake actions are inside the padded wrapper
- verifies inline and computed 22px side/bottom padding
- verifies the visible v7 build marker

## Verification
- focused MCP suite: 23/23 passed
- full suite: 31 suites, 339/339 tests passed
- `git diff --check` passed