### PR TITLE
feat(plugin): add attempts and native difficulty guidance

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,9 @@
 [build]
   publish = "public"
-  # Skip builds if no meaningful runtime paths changed:
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- public/ src/ netlify/functions/ package*.json netlify.toml"
+  # Skip builds if no meaningful runtime paths changed. A stale production
+  # cache may reference a commit outside the current shallow checkout; in that
+  # case return 1 so Netlify performs a clean build instead of failing early.
+  ignore = "if git cat-file -e \"$CACHED_COMMIT_REF^{commit}\" 2>/dev/null && git cat-file -e \"$COMMIT_REF^{commit}\" 2>/dev/null; then git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- public/ src/ netlify/functions/ package*.json netlify.toml; else exit 1; fi"
 
 [functions]
   directory = "netlify/functions"
@@ -94,6 +96,14 @@
 [[redirects]]
   from = "/mcp"
   to = "/.netlify/functions/mcp"
+  status = 200
+  force = true
+
+# OpenAI Apps submission domain verification. Configure the portal-provided
+# value as OPENAI_APPS_CHALLENGE in Netlify before requesting verification.
+[[redirects]]
+  from = "/.well-known/openai-apps-challenge"
+  to = "/.netlify/functions/openai-apps-challenge"
   status = 200
   force = true
 

--- a/netlify/functions/__tests__/mcp.test.js
+++ b/netlify/functions/__tests__/mcp.test.js
@@ -85,9 +85,12 @@ describe('EZ Quiz MCP server', () => {
     expect(initialized.statusCode).toBe(200);
     expect(json(initialized).result).toMatchObject({
       protocolVersion: '2025-06-18',
-      serverInfo: { name: 'ez-quiz', version: '2.0.0' },
+      serverInfo: { name: 'ez-quiz', version: '2.1.0' },
     });
     expect(json(initialized).result.instructions).toContain('write and fact-check the complete quiz yourself');
+    expect(json(initialized).result.instructions).toContain('Difficulty comes from the thinking required');
+    expect(json(initialized).result.instructions).toContain('Much harder, extreme, brutal, or expert means expert');
+    expect(json(initialized).result.instructions).toContain('hidden instructor knowledge');
 
     const listed = await handler(event({ jsonrpc: '2.0', id: 2, method: 'tools/list' }));
     const listedTools = json(listed).result.tools;
@@ -95,11 +98,16 @@ describe('EZ Quiz MCP server', () => {
     expect(listedTools[0]).toMatchObject({
       inputSchema: { required: ['title', 'topic', 'questions'], additionalProperties: false },
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v7.html' } },
+      _meta: { ui: { resourceUri: 'ui://ez-quiz/quiz-v8.html' } },
     });
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('source_text');
     expect(listedTools[0].inputSchema.properties).not.toHaveProperty('lines');
     expect(listedTools[0].description).toContain('already written');
+    expect(listedTools[0].description).toContain('reasoning burden');
+    expect(listedTools[0].inputSchema.properties.difficulty.enum).toEqual([
+      'easy', 'medium', 'hard', 'expert', 'mixed',
+    ]);
+    expect(listedTools[0].inputSchema.properties.difficulty.description).toContain('advanced diagnosis');
   });
 
   test('serves a self-contained runner with no generation or network dependencies', async () => {
@@ -146,6 +154,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v5.html',
       'ui://ez-quiz/quiz-v6.html',
       'ui://ez-quiz/quiz-v7.html',
+      'ui://ez-quiz/quiz-v8.html',
     ]);
 
     for (const uri of [
@@ -156,6 +165,7 @@ describe('EZ Quiz MCP server', () => {
       'ui://ez-quiz/quiz-v5.html',
       'ui://ez-quiz/quiz-v6.html',
       'ui://ez-quiz/quiz-v7.html',
+      'ui://ez-quiz/quiz-v8.html',
     ]) {
       const read = await handler(event({ jsonrpc: '2.0', id: 32, method: 'resources/read', params: { uri } }));
       expect(json(read).result.contents[0]).toMatchObject({ uri, mimeType: 'text/html;profile=mcp-app' });
@@ -194,6 +204,34 @@ describe('EZ Quiz MCP server', () => {
       jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'open_quiz', arguments: args },
     }));
     expect(json(repeated).result.structuredContent.quizId).toBe(result.structuredContent.quizId);
+  });
+
+  test('accepts expert as a native ChatGPT-authored difficulty tier', async () => {
+    const { handler } = require('../mcp.js');
+    const response = await handler(event({
+      jsonrpc: '2.0', id: 41, method: 'tools/call', params: {
+        name: 'open_quiz',
+        arguments: {
+          title: 'Expert Routing Diagnosis',
+          topic: 'OSPF troubleshooting',
+          difficulty: 'expert',
+          questions: [{
+            type: 'MC',
+            text: 'Two OSPF neighbors remain in EXSTART after MTU values diverge. Which change most directly addresses the adjacency failure?',
+            options: [
+              'Make the interface MTU values agree',
+              'Increase the hello interval on only one router',
+              'Remove the shared area from both interfaces',
+              'Change both router IDs to the same value',
+            ],
+            correct: [0],
+          }],
+        },
+      },
+    }));
+    expect(json(response).result.structuredContent).toMatchObject({
+      difficulty: 'expert', questionCount: 1, aiGenerated: true,
+    });
   });
 
   test('dispatches cached generate_quiz and render_quiz calls without advertising them', async () => {
@@ -312,8 +350,9 @@ describe('EZ Quiz MCP server', () => {
     document.querySelector('#next').click();
 
     expect(document.querySelector('.results-copy h1').textContent).toBe('Quiz complete');
+    expect(document.querySelector('.results-copy p').textContent).toContain('Attempt 1');
     expect(document.querySelector('.score-orb').textContent).toBe('2/2');
-    expect(states.at(-1)).toMatchObject({ mode: 'results', answers: [[1], true] });
+    expect(states.at(-1)).toMatchObject({ mode: 'results', answers: [[1], true], attemptNumber: 1 });
     expect(document.querySelector('.result-stat.correct strong').textContent).toBe('2');
     expect(document.querySelector('.result-stat.missed strong').textContent).toBe('0');
     expect(document.querySelectorAll('.result-actions button')).toHaveLength(2);
@@ -391,10 +430,40 @@ describe('EZ Quiz MCP server', () => {
     clickInput('input[value="true"]');
     document.querySelector('#next').click();
     expect(document.querySelector('.score-orb').textContent).toBe('2/2');
+    expect(document.querySelector('.results-copy p').textContent).toContain('Attempt 2');
+  });
+
+  test('counts each retake once while ignoring stale taps and repeated tool delivery', () => {
+    const output = quiz();
+    const states = [];
+    const { html, script } = widgetDocument();
+    mountWidget(html, { toolOutput: output, setWidgetState: (state) => states.push(state) });
+    window.eval(script);
+    clickInput('input[value="1"]');
+    document.querySelector('#next').click();
+    clickInput('input[value="true"]');
+    document.querySelector('#next').click();
+
+    const staleRetakeAll = document.querySelector('#retakeAll');
+    staleRetakeAll.click();
+    staleRetakeAll.click();
+    expect(states.at(-1)).toMatchObject({ mode: 'quiz', attemptNumber: 2 });
+
+    window.dispatchEvent(new CustomEvent('openai:set_globals', { detail: { globals: { toolOutput: output } } }));
+    expect(states.at(-1).attemptNumber).toBe(2);
+    clickInput('input[value="1"]');
+    document.querySelector('#next').click();
+    clickInput('input[value="true"]');
+    document.querySelector('#next').click();
+    expect(document.querySelector('.results-copy p').textContent).toContain('Attempt 2');
+    expect(states).toContainEqual(expect.objectContaining({
+      quizId: output.quizId, mode: 'results', attemptNumber: 2,
+    }));
   });
 
   test('restores persisted runner state for the same quiz', () => {
     const output = quiz();
+    const setWidgetState = jest.fn();
     const { html, script } = widgetDocument();
     mountWidget(html, {
       toolOutput: output,
@@ -402,13 +471,15 @@ describe('EZ Quiz MCP server', () => {
         version: 2, quizId: output.quizId, mode: 'quiz', attemptIndexes: [0, 1],
         answers: [[1], null], index: 1,
         startedAt: Date.now() - 1000, finishedAt: 0,
+        attemptNumber: 4,
       },
-      setWidgetState: jest.fn(),
+      setWidgetState,
     });
     window.eval(script);
     expect(document.querySelector('h2').textContent).toContain('OSPF');
     document.querySelector('#previous').click();
     expect(document.querySelector('input[value="1"]').checked).toBe(true);
+    expect(setWidgetState).toHaveBeenLastCalledWith(expect.objectContaining({ attemptNumber: 4 }));
   });
 
   test('follows system theme and standard safe-area context without launching a modal', async () => {
@@ -545,7 +616,7 @@ describe('EZ Quiz MCP server', () => {
     expect(document.documentElement.dataset.size).toBeUndefined();
     const resultsView = document.querySelector('.results-view');
     expect(resultsView).not.toBeNull();
-    expect(resultsView.dataset.widgetVersion).toBe('7');
+    expect(resultsView.dataset.widgetVersion).toBe('8');
     expect(resultsView.style.padding).toBe('20px 22px 22px');
     expect(resultsView.contains(document.querySelector('.score-orb'))).toBe(true);
     expect(resultsView.contains(document.querySelector('.result-actions'))).toBe(true);
@@ -553,7 +624,7 @@ describe('EZ Quiz MCP server', () => {
     expect(resultsStyle.paddingLeft).toBe('22px');
     expect(resultsStyle.paddingRight).toBe('22px');
     expect(resultsStyle.paddingBottom).toBe('22px');
-    expect(document.querySelector('.widget-build').textContent).toBe('v7');
+    expect(document.querySelector('.widget-build').textContent).toBe('v8');
     expect(document.querySelector('.result-summary').textContent).toContain('Question 2');
     expect(document.querySelectorAll('.result-actions button')).toHaveLength(2);
     expect(document.querySelector('#retakeMissed').disabled).toBe(false);

--- a/netlify/functions/__tests__/openai-apps-challenge.test.js
+++ b/netlify/functions/__tests__/openai-apps-challenge.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+describe('OpenAI Apps domain challenge', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.OPENAI_APPS_CHALLENGE;
+  });
+
+  afterAll(() => { process.env = originalEnv; });
+
+  test('stays unavailable until the portal token is configured', async () => {
+    const { handler } = require('../openai-apps-challenge.js');
+    await expect(handler({ httpMethod: 'GET' })).resolves.toMatchObject({
+      statusCode: 404,
+      headers: { 'Cache-Control': 'no-store', 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  });
+
+  test('returns the exact configured token for GET and an empty HEAD response', async () => {
+    process.env.OPENAI_APPS_CHALLENGE = 'openai-apps-domain-token_123';
+    const { handler } = require('../openai-apps-challenge.js');
+    await expect(handler({ httpMethod: 'GET' })).resolves.toMatchObject({
+      statusCode: 200,
+      body: 'openai-apps-domain-token_123',
+    });
+    await expect(handler({ httpMethod: 'HEAD' })).resolves.toMatchObject({ statusCode: 200, body: '' });
+  });
+
+  test('rejects unsafe token values and unsupported methods', async () => {
+    process.env.OPENAI_APPS_CHALLENGE = 'bad\r\ntoken';
+    const { handler } = require('../openai-apps-challenge.js');
+    await expect(handler({ httpMethod: 'GET' })).resolves.toMatchObject({ statusCode: 404 });
+    await expect(handler({ httpMethod: 'POST' })).resolves.toMatchObject({
+      statusCode: 405,
+      headers: { Allow: 'GET, HEAD' },
+    });
+  });
+});

--- a/netlify/functions/lib/mcpQuizContract.js
+++ b/netlify/functions/lib/mcpQuizContract.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const {
+  DIFFICULTY_SCHEMA_DESCRIPTION,
+  QUIZ_DIFFICULTIES,
+} = require('./mcpQuizGuidance.js');
 
 const MAX_QUESTIONS = 20;
 const MAX_OPTIONS = 8;
@@ -106,9 +110,9 @@ const openQuizInputSchema = {
     topic: textField('The subject being tested.', 240),
     difficulty: {
       type: 'string',
-      enum: ['easy', 'medium', 'hard', 'mixed'],
+      enum: [...QUIZ_DIFFICULTIES],
       default: 'medium',
-      description: 'Overall quiz difficulty.',
+      description: DIFFICULTY_SCHEMA_DESCRIPTION,
     },
     questions: {
       type: 'array',
@@ -151,7 +155,7 @@ const quizOutputSchema = {
     quizId: { type: 'string' },
     title: { type: 'string' },
     topic: { type: 'string' },
-    difficulty: { type: 'string', enum: ['easy', 'medium', 'hard', 'mixed'] },
+    difficulty: { type: 'string', enum: [...QUIZ_DIFFICULTIES] },
     questions: { type: 'array', items: canonicalQuestionOutputSchema },
     questionCount: { type: 'integer' },
     aiGenerated: { type: 'boolean' },
@@ -260,8 +264,8 @@ function normalizeOpenQuizArgs(value) {
   const title = strictString(raw.title, 'title', 160);
   const topic = strictString(raw.topic, 'topic', 240);
   const difficulty = String(raw.difficulty || 'medium').trim().toLowerCase();
-  if (!['easy', 'medium', 'hard', 'mixed'].includes(difficulty)) {
-    throw new Error('difficulty must be easy, medium, hard, or mixed');
+  if (!QUIZ_DIFFICULTIES.includes(difficulty)) {
+    throw new Error(`difficulty must be ${QUIZ_DIFFICULTIES.slice(0, -1).join(', ')}, or ${QUIZ_DIFFICULTIES.at(-1)}`);
   }
   if (!Array.isArray(raw.questions) || raw.questions.length < 1 || raw.questions.length > MAX_QUESTIONS) {
     throw new Error(`questions must contain 1 to ${MAX_QUESTIONS} items`);

--- a/netlify/functions/lib/mcpQuizGuidance.js
+++ b/netlify/functions/lib/mcpQuizGuidance.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const QUIZ_DIFFICULTIES = Object.freeze(['easy', 'medium', 'hard', 'expert', 'mixed']);
+
+const DIFFICULTY_SCHEMA_DESCRIPTION = [
+  'The reasoning target for the complete quiz.',
+  'easy checks direct facts, definitions, purposes, commands, or basic behavior without tricks;',
+  'medium uses compact application that requires one inference, comparison, or cause-and-effect link;',
+  'hard uses realistic applied judgment, troubleshooting, tradeoffs, or multi-step reasoning;',
+  'expert uses advanced diagnosis, edge cases, competing interpretations, and subtle but useful distinctions;',
+  'mixed deliberately progresses from foundations through applied and advanced reasoning.',
+].join(' ');
+
+const CHATGPT_QUIZ_INSTRUCTIONS = [
+  'When the user asks for an EZ Quiz, write and fact-check the complete quiz yourself, then call open_quiz exactly once with structured questions.',
+  'Use the conversation and user-supplied sources as hidden instructor knowledge. Every question and answer choice must stand alone; never refer to notes, files, source material, or provided text in the learner-facing quiz.',
+  'Honor an explicit question count, topic, format, and difficulty request. If no difficulty is requested, use medium.',
+  'Difficulty comes from the thinking required, not dense wording, obscure trivia, vague abstractions, or sneaky absolute words. Keep language clear and use technical terms only when the subject requires them.',
+  'Easy tests one direct fact, definition, purpose, command, function, or basic behavior with short stems and no trick wording.',
+  'Medium tests applied understanding with compact realistic scenarios requiring one inference, comparison, or cause-and-effect link; distractors are plausible but fair.',
+  'Hard tests applied judgment, important distinctions, troubleshooting, design tradeoffs, command or evidence interpretation, or multi-step reasoning in the subject\'s real context.',
+  'Expert tests advanced multi-step diagnosis, edge cases, competing interpretations, hidden dependencies, or subtle relationships while keeping one clearly supportable answer. Prefer useful mastery over niche trivia.',
+  'Mixed difficulty should form a deliberate progression from direct foundations to application and then demanding synthesis, rather than a random blend.',
+  'For relative requests, use the most recent quiz level when known: harder moves easy to medium, medium to hard, and hard to expert; easier moves in the opposite direction. Much harder, extreme, brutal, or expert means expert. If an expert quiz is made harder, deepen the diagnosis or distinctions without resorting to obscurity.',
+  'Prefer authentic subject-matter questions such as troubleshooting, behavior, configuration, evidence interpretation, chronology, comparison, and tradeoff decisions when relevant.',
+  'Make multiple-choice options complete, distinct, and grammatically parallel. Use multiple correct indexes only when the stem explicitly says to select multiple answers. True/false and yes/no items should test one claim at a time.',
+  'Do not ask EZ Quiz to generate questions, do not send raw source material to the tool, and do not create loading or placeholder quiz calls.',
+  'The EZ Quiz component owns question navigation, scoring, results review, attempt counting, and retakes.',
+].join(' ');
+
+module.exports = {
+  CHATGPT_QUIZ_INSTRUCTIONS,
+  DIFFICULTY_SCHEMA_DESCRIPTION,
+  QUIZ_DIFFICULTIES,
+};

--- a/netlify/functions/lib/mcpQuizWidget.js
+++ b/netlify/functions/lib/mcpQuizWidget.js
@@ -4,7 +4,7 @@ const { BRAND_WORDMARK_DATA_URI } = require('./mcpQuizBrand.js');
 
 // Widget template URIs are cache keys. Publish breaking layout revisions under
 // a fresh URI while continuing to serve old aliases for cached tool descriptors.
-const QUIZ_WIDGET_VERSION = 7;
+const QUIZ_WIDGET_VERSION = 8;
 const QUIZ_WIDGET_URI = `ui://ez-quiz/quiz-v${QUIZ_WIDGET_VERSION}.html`;
 const QUIZ_WIDGET_ALIASES = Object.freeze([
   'ui://ez-quiz/quiz-v1.html',
@@ -13,6 +13,7 @@ const QUIZ_WIDGET_ALIASES = Object.freeze([
   'ui://ez-quiz/quiz-v4.html',
   'ui://ez-quiz/quiz-v5.html',
   'ui://ez-quiz/quiz-v6.html',
+  'ui://ez-quiz/quiz-v7.html',
   QUIZ_WIDGET_URI,
 ]);
 const QUIZ_WIDGET_MIME_TYPE = 'text/html;profile=mcp-app';
@@ -471,6 +472,7 @@ function quizWidgetHtml() {
       let index = 0;
       let startedAt = 0;
       let finishedAt = 0;
+      let attemptNumber = 1;
 
       const esc = (value) => String(value == null ? '' : value).replace(/[&<>"']/g, (char) => ({
         '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
@@ -609,6 +611,7 @@ function quizWidgetHtml() {
           index,
           startedAt,
           finishedAt,
+          attemptNumber,
         };
       }
 
@@ -690,6 +693,11 @@ function quizWidgetHtml() {
         return indexes.length === value.length && new Set(indexes).size === indexes.length ? indexes : null;
       }
 
+      function validAttemptNumber(value) {
+        const parsed = Number(value);
+        return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : 1;
+      }
+
       function restoreState(data) {
         const prior = window.openai && window.openai.widgetState;
         if (!prior || prior.version !== 2 || String(prior.quizId || '') !== data.quizId) return false;
@@ -701,6 +709,7 @@ function quizWidgetHtml() {
         mode = prior.mode === 'results' ? 'results' : 'quiz';
         startedAt = Number(prior.startedAt) > 0 ? Number(prior.startedAt) : Date.now();
         finishedAt = mode === 'results' && Number(prior.finishedAt) > 0 ? Number(prior.finishedAt) : 0;
+        attemptNumber = validAttemptNumber(prior.attemptNumber);
         return true;
       }
 
@@ -849,11 +858,14 @@ function quizWidgetHtml() {
       }
 
       function beginRetake(indexes) {
-        if (!indexes.length) return;
-        indexes.forEach((questionIndex) => { answers[questionIndex] = null; });
-        attemptIndexes = indexes.slice();
-        index = 0;
+        if (mode !== 'results' || !quiz) return;
+        const nextIndexes = validAttemptIndexes(indexes, quiz.questions.length);
+        if (!nextIndexes) return;
         mode = 'quiz';
+        attemptNumber += 1;
+        nextIndexes.forEach((questionIndex) => { answers[questionIndex] = null; });
+        attemptIndexes = nextIndexes;
+        index = 0;
         startedAt = Date.now();
         finishedAt = 0;
         saveQuizState();
@@ -875,7 +887,7 @@ function quizWidgetHtml() {
           : '<strong>All correct.</strong> You are ready for a harder round.';
         renderHtml(
           '<section class="results-view" data-widget-version="${QUIZ_WIDGET_VERSION}" style="padding:20px 22px 22px"><div class="results-head"><div class="score-orb" aria-label="' + score + ' out of ' + quiz.questions.length + '">' + score + '/' + quiz.questions.length + '</div>' +
-          '<div class="results-copy"><h1>Quiz complete</h1><p>' + esc(message) + ' · ' + formatDuration(finishedAt - startedAt) + '</p></div></div>' +
+          '<div class="results-copy"><h1>Quiz complete</h1><p>' + esc(message) + ' · Attempt ' + attemptNumber + ' · ' + formatDuration(finishedAt - startedAt) + '</p></div></div>' +
           '<div class="result-progress"><div class="progress" role="progressbar" aria-label="Final score" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' + percent + '">' +
           '<span style="width:' + percent + '%"></span></div></div>' +
           '<div class="result-stats" aria-label="Quiz results"><div class="result-stat correct"><strong>' + score + '</strong><span>Correct</span></div>' +
@@ -921,6 +933,7 @@ function quizWidgetHtml() {
           index = 0;
           startedAt = Date.now();
           finishedAt = 0;
+          attemptNumber = 1;
         }
         if (mode === 'results') renderResults(); else renderQuestion();
         return true;
@@ -976,7 +989,7 @@ function quizWidgetHtml() {
 
       request('ui/initialize', {
         protocolVersion: '2026-01-26',
-        appInfo: { name: 'ez-quiz-player', title: 'EZ Quiz', version: '4.1.0', websiteUrl: '${SITE_ORIGIN}' },
+        appInfo: { name: 'ez-quiz-player', title: 'EZ Quiz', version: '4.2.0', websiteUrl: '${SITE_ORIGIN}' },
         appCapabilities: {},
       }).then((result) => {
         bridgeInitialized = true;

--- a/netlify/functions/mcp.js
+++ b/netlify/functions/mcp.js
@@ -12,9 +12,10 @@ const {
   QUIZ_WIDGET_URI,
   quizWidgetHtml,
 } = require('./lib/mcpQuizWidget.js');
+const { CHATGPT_QUIZ_INSTRUCTIONS } = require('./lib/mcpQuizGuidance.js');
 const { parseLegacyQuestion } = require('./lib/normalizer.js');
 
-const SERVER_INFO = { name: 'ez-quiz', version: '2.0.0' };
+const SERVER_INFO = { name: 'ez-quiz', version: '2.1.0' };
 const DEFAULT_PROTOCOL_VERSION = '2025-06-18';
 const LEGACY_TYPES = new Set(['MC', 'TF', 'YN', 'MT']);
 
@@ -27,6 +28,7 @@ const tools = [{
     'Before calling it, write and fact-check the entire question set from the conversation and any source material the user supplied.',
     'Do not call it with placeholders, generation status, raw source text, or incomplete questions.',
     'Prefer 5 to 10 questions unless the user requests another count, and keep every question self-contained.',
+    'Set the difficulty field to the level you actually wrote; expert and relative difficulty requests must change the reasoning burden, not merely the label.',
   ].join(' '),
   inputSchema: openQuizInputSchema,
   outputSchema: quizOutputSchema,
@@ -300,12 +302,7 @@ async function dispatch(message, event) {
         resources: { subscribe: false, listChanged: false },
       },
       serverInfo: SERVER_INFO,
-      instructions: [
-        'When the user asks for an EZ Quiz, write and fact-check the complete quiz yourself, then call open_quiz exactly once with structured questions.',
-        'Use the conversation and user-supplied sources as the knowledge context.',
-        'Do not ask EZ Quiz to generate questions, do not send raw source material to the tool, and do not create loading or placeholder quiz calls.',
-        'The EZ Quiz component owns question navigation, scoring, results review, and retakes.',
-      ].join(' '),
+      instructions: CHATGPT_QUIZ_INSTRUCTIONS,
     });
   }
   if (message.method === 'ping') return rpcResult(id, {});

--- a/netlify/functions/openai-apps-challenge.js
+++ b/netlify/functions/openai-apps-challenge.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function plainResponse(statusCode, body, headers = {}) {
+  return {
+    statusCode,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      ...headers,
+    },
+    body,
+  };
+}
+
+exports.handler = async (event = {}) => {
+  const method = String(event.httpMethod || 'GET').toUpperCase();
+  if (method !== 'GET' && method !== 'HEAD') {
+    return plainResponse(405, 'Method not allowed', { Allow: 'GET, HEAD' });
+  }
+
+  const token = String(process.env.OPENAI_APPS_CHALLENGE || '').trim();
+  if (!token || token.length > 2048 || /[\r\n]/.test(token)) {
+    return plainResponse(404, 'Domain verification is not configured');
+  }
+
+  return plainResponse(200, method === 'HEAD' ? '' : token);
+};


### PR DESCRIPTION
## Summary
- count quiz runs as Attempt 1, Attempt 2, and so on without double-counting stale taps, remounts, or duplicate tool results
- teach ChatGPT the EZ Quiz difficulty model from easy through expert, including relative requests and deliberate mixed progression
- keep source material hidden from learner-facing questions and preserve fair, topic-appropriate distractor guidance
- publish widget v8 while retaining all cached resource aliases
- prewire the OpenAI Apps domain-verification endpoint
- let Netlify production rebuild cleanly when its cached commit is missing from a shallow checkout

## Verification
- 32 Jest suites passed
- 344 tests passed
- MCP function and domain challenge bundled successfully in the offline Netlify production build
- custom Netlify ignore command returns 1 for a missing cached ref and 0 for identical valid refs

The legacy Gemini compatibility handler is unchanged; ChatGPT authors the plugin questions natively.