### PR TITLE
fix(deploy): always build production mirror commits

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,8 @@
 [build]
   publish = "public"
-  # Skip builds if no meaningful runtime paths changed. A stale production
-  # cache may reference a commit outside the current shallow checkout; in that
-  # case return 1 so Netlify performs a clean build instead of failing early.
-  ignore = "if git cat-file -e \"$CACHED_COMMIT_REF^{commit}\" 2>/dev/null && git cat-file -e \"$COMMIT_REF^{commit}\" 2>/dev/null; then git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- public/ src/ netlify/functions/ package*.json netlify.toml; else exit 1; fi"
+  # Build every production mirror commit. Netlify's cached base ref is not
+  # guaranteed to exist in a shallow production checkout, so an ignore command
+  # can fail before the actual build starts.
 
 [functions]
   directory = "netlify/functions"


### PR DESCRIPTION
Removes the custom Netlify `ignore` hook so production mirror commits always enter the real build.

The identical App PR #81 deploy preview completed successfully, but the production deploy failed in roughly three seconds before build output or functions existed. Production is the only context that evaluates this optimization. Removing it has no runtime behavior change; it trades skipped no-op builds for reliable releases.

Verification:
- `git diff --check`
- 32 suites, 344 tests passed
- Preview release already protocol-verified on App PR #81